### PR TITLE
better hint positioning for all fonts and sizes

### DIFF
--- a/public/css/style.scss
+++ b/public/css/style.scss
@@ -1789,9 +1789,9 @@ key {
 
 .word letter.incorrect hint {
   position: absolute;
-  bottom: -1.2em;
+  bottom: -1em;
   color: var(--text-color);
-  line-height: 1em;
+  line-height: initial;
   font-size: .75em;
   text-shadow: none;
   padding: 1px;


### PR DESCRIPTION
this tweak makes the incorrect word hint be positioned in the middle of the lines and not overlapping the upper or lower lines in any font family or in any font size