### PR TITLE
Fixed switching back to english when exiting quote mode

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -3075,7 +3075,7 @@ function changeMode(mode, nosave) {
     $("#top .config .numbersMode").addClass("hidden");
     $("#result .stats .source").removeClass("hidden");
     $("#top .config .quoteLength").removeClass("hidden");
-    changeLanguage("english", nosave);
+    // changeLanguage("english", nosave);
   }
   if (!nosave) saveConfigToCookie();
 }


### PR DESCRIPTION
As referenced in [this](https://github.com/Miodec/monkeytype/issues/475) issue, I found the line that caused the switch to English when entering quote mode, and commented it as for it not to force the user in English mode. From my understanding, this won't affect the quotes, as they are all pre-written in English. 
As I tested it, the fix worked for the problem, but if it somehow conflicts with the scoreboard, I'm ok to it not being accepted.
I didn't notice the language in which a test was taken anywhere in the recent tests scoreboard. 

_Thank you for the opportunity, I love your project btw 😄_ 