### PR TITLE
Add Iceberg Dark and Iceberg Light themes

### DIFF
--- a/static/themes/iceberg_dark.css
+++ b/static/themes/iceberg_dark.css
@@ -1,8 +1,8 @@
 :root {
   --bg-color: #161821;
   --caret-color: #d2d4de;
-  --main-color: #d2d4de;
-  --sub-color: #84a0c6;
+  --main-color: #84a0c6;
+  --sub-color: #c6c8d1;
   --text-color: #c6c8d1;
   --error-color: #e27878;
   --error-extra-color: #e2a478;

--- a/static/themes/iceberg_dark.css
+++ b/static/themes/iceberg_dark.css
@@ -1,0 +1,11 @@
+:root {
+  --bg-color: #161821;
+  --caret-color: #d2d4de;
+  --main-color: #d2d4de;
+  --sub-color: #84a0c6;
+  --text-color: #c6c8d1;
+  --error-color: #e27878;
+  --error-extra-color: #e2a478;
+  --colorful-error-color: #e27878;
+  --colorful-error-extra-color: #e2a478;
+}

--- a/static/themes/iceberg_light.css
+++ b/static/themes/iceberg_light.css
@@ -1,0 +1,11 @@
+:root {
+  --bg-color: #e8e9ec;
+  --caret-color: #262a3f;
+  --main-color: #262a3f;
+  --sub-color: #2d539e;
+  --text-color: #33374c;
+  --error-color: #cc517a;
+  --error-extra-color: #cc3768;
+  --colorful-error-color: #cc517a;
+  --colorful-error-extra-color: #cc3768;
+}

--- a/static/themes/iceberg_light.css
+++ b/static/themes/iceberg_light.css
@@ -1,8 +1,8 @@
 :root {
   --bg-color: #e8e9ec;
   --caret-color: #262a3f;
-  --main-color: #262a3f;
-  --sub-color: #2d539e;
+  --main-color: #2d539e;
+  --sub-color: #262a3f;
   --text-color: #33374c;
   --error-color: #cc517a;
   --error-extra-color: #cc3768;

--- a/static/themes/list.json
+++ b/static/themes/list.json
@@ -423,5 +423,15 @@
     "name": "drowning",
     "bgColor": "#191826",
     "textColor": "#4a6fb5"
+  },
+  {
+    "name": "iceberg_dark",
+    "bgColor": "#161821",
+    "textColor": "#c6c8d1"
+  },
+  {
+    "name": "iceberg_light",
+    "bgColor": "#e8e9ec",
+    "textColor": "#33374c"
   }
 ]


### PR DESCRIPTION
Port of [iceberg.vim](https://github.com/cocopon/iceberg.vim).

Before you merge though, is there any way I can override the color for time/word counter? I find the automatic one not distinct enough on the dark variant.

Previews:
light
![image](https://user-images.githubusercontent.com/20600053/98439636-32c09600-2104-11eb-941e-ae4e1ee60bcf.png)

dark
![image](https://user-images.githubusercontent.com/20600053/98439622-289e9780-2104-11eb-916c-6ef0d2195dd0.png)

(screenshots updated to reflect latest commit)
