### PR TITLE
Adding jquery gsap plugin

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -3430,6 +3430,8 @@
   <script src="js/jquery.color.min.js"></script>
   <script src="js/easing.js"></script>
   <script src="js/jquery.cookie-1.4.1.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/2.1.3/TweenMax.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/2.1.3/jquery.gsap.min.js"></script>
   <script src="js/moment.min.js"></script>
   <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.3/Chart.min.js"></script> -->
   <script src="js/chart.min.js"></script>


### PR DESCRIPTION
This is a monkey patch that hopefully makes animations smoother at high refresh rates. It simply overrides `jQuery.animate()` with gsap, which claims to be up to 20x faster than jquery. See example speed test https://greensock.com/js/speed.html

The gsap jquery plugin is discontinued. For a more permanent solution, I think we should switch to css animations or (non-jquery) gsap.