### PR TITLE
Removed unused turkish char

### DIFF
--- a/static/languages/turkish.json
+++ b/static/languages/turkish.json
@@ -77,7 +77,7 @@
     "yeni",
     "önce",
     "başka",
-    "hâl",
+    "hal",
     "orta",
     "su",
     "girmek",


### PR DESCRIPTION
Fixed hâl to hal because you need to press shift+3+a to type that char which makes it practically very difficult for these kind of tests and also we most commonly type that word "hal".