### PR TITLE
Fix sub-color according to contrast 

### DIFF
--- a/static/themes/matrix.css
+++ b/static/themes/matrix.css
@@ -2,7 +2,7 @@
   --bg-color: #000000;
   --main-color: #15ff00;
   --caret-color: #15ff00;
-  --sub-color: #032700;
+  --sub-color: #003B00;
   --text-color: #adffa7;
   --error-color: #da3333;
   --error-extra-color: #791717;


### PR DESCRIPTION
Fixed issue #635 "Problem: Cannot see anything while using RGB and Matrix theme "
Matrix sub-color changed according to theme

Old matrix theme sub-color: #032700 Luminosity Contrast Ratio: 1.29:1 to #003B00 Luminosity Contrast Ratio: 1.63:1

Rgb theme sub-color: #444444 Luminosity Contrast Ratio: 1.94:1 which has contrast similar to other themes

