### PR TITLE
Optimize appending to the dom

### DIFF
--- a/src/js/commandline.js
+++ b/src/js/commandline.js
@@ -2023,14 +2023,15 @@ function updateSuggestedCommands() {
 
 function displayFoundCommands() {
   $("#commandLine .suggestions").empty();
+  let commandsHTML = "";
   let list = currentCommands[currentCommands.length - 1];
   $.each(list.list, (index, obj) => {
     if (obj.found && (obj.available !== undefined ? obj.available() : true)) {
-      $("#commandLine .suggestions").append(
-        '<div class="entry" command="' + obj.id + '">' + obj.display + "</div>"
-      );
+      commandsHTML +=
+        '<div class="entry" command="' + obj.id + '">' + obj.display + "</div>";
     }
   });
+  $("#commandLine .suggestions").html(commandsHTML);
   if ($("#commandLine .suggestions .entry").length == 0) {
     $("#commandLine .separator").css({ height: 0, margin: 0 });
   } else {

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -3106,6 +3106,7 @@ function toggleResultWordsDisplay() {
 
 async function loadWordsHistory() {
   $("#resultWordsHistory .words").empty();
+  let wordsHTML = "";
   for (let i = 0; i < inputHistory.length + 2; i++) {
     let input = inputHistory[i];
     let wordEl = "";
@@ -3216,8 +3217,9 @@ async function loadWordsHistory() {
         wordEl += "</div>";
       } catch (e) {}
     }
-    $("#resultWordsHistory .words").append(wordEl);
+    wordsHTML += wordEl;
   }
+  $("#resultWordsHistory .words").html(wordsHTML);
   $("#showWordHistoryButton").addClass("loaded");
   return true;
 }

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -843,14 +843,15 @@ function addWord() {
 function showWords() {
   $("#words").empty();
 
+  let wordsHTML = "";
   for (let i = 0; i < wordsList.length; i++) {
-    let w = "<div class='word'>";
+    wordsHTML += "<div class='word'>";
     for (let c = 0; c < wordsList[i].length; c++) {
-      w += "<letter>" + wordsList[i].charAt(c) + "</letter>";
+      wordsHTML += "<letter>" + wordsList[i].charAt(c) + "</letter>";
     }
-    w += "</div>";
-    $("#words").append(w);
+    wordsHTML += "</div>";
   }
+  $("#words").html(wordsHTML);
 
   $("#wordsWrapper").removeClass("hidden");
   const wordHeight = $(document.querySelector(".word")).outerHeight(true);


### PR DESCRIPTION
Appending to the dom in a loop is slow. By simply moving append out of the loop, we can speed up showing the word list, the word history, and the single list command line.

There are other instances of this antipattern in the code, but fixing these three should already have high impact.