### PR TITLE
Fix Typo in Settings

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -2337,7 +2337,7 @@
               <div class="section showAllLines">
                 <h1>show all lines</h1>
                 <div class="text">
-                  When enabled, the website will show all lines for word,custom
+                  When enabled, the website will show all lines for word, custom
                   and quote mode tests - otherwise the lines will be limited to
                   3, and will automatically scroll. Using this could cause the
                   timer text and live wpm to not be visible.


### PR DESCRIPTION
Noticed a missing whitespace in the description for `show all lines` in the settings page.