### PR TITLE
Add Repose dark and light themes

### DIFF
--- a/static/themes/list.json
+++ b/static/themes/list.json
@@ -445,12 +445,12 @@
     "textColor": "#ffffff"
   },
   {
-    "name": "repose dark",
+    "name": "repose_dark",
     "bgColor": "#2f3338",
     "textColor": "#d6d2bc"
   },
   {
-    "name": "repose light",
+    "name": "repose_light",
     "bgColor": "#efead0",
     "textColor": "#333538"
   }

--- a/static/themes/list.json
+++ b/static/themes/list.json
@@ -443,5 +443,15 @@
     "name": "darling",
     "bgColor": "#fec8cd",
     "textColor": "#ffffff"
+  },
+  {
+    "name": "repose dark",
+    "bgColor": "#2f3338",
+    "textColor": "#d6d2bc"
+  },
+  {
+    "name": "repose light",
+    "bgColor": "#efead0",
+    "textColor": "#333538"
   }
 ]

--- a/static/themes/repose_dark.css
+++ b/static/themes/repose_dark.css
@@ -1,0 +1,11 @@
+:root {
+  --bg-color: #2F3338;
+  --main-color: #D6D2BC;
+  --caret-color: #D6D2BC;
+  --sub-color: #8F8E84;
+  --text-color: #D6D2BC;
+  --error-color: #FF4A59;
+  --error-extra-color: #C43C53;
+  --colorful-error-color: #FF4A59;
+  --colorful-error-extra-color: #C43C53;
+}

--- a/static/themes/repose_light.css
+++ b/static/themes/repose_light.css
@@ -1,0 +1,11 @@
+:root {
+  --bg-color: #EFEAD0;
+  --main-color: #5F605E;
+  --caret-color: #5F605E;
+  --sub-color: #8F8E84;
+  --text-color: #333538;
+  --error-color: #C43C53;
+  --error-extra-color: #A52632;
+  --colorful-error-color: #C43C53;
+  --colorful-error-extra-color: #A52632;
+}


### PR DESCRIPTION
Port of https://github.com/repose-theme/repose

![image](https://user-images.githubusercontent.com/72284051/101297310-f8731300-37ed-11eb-9735-2fbc040a3e0c.png)
![image](https://user-images.githubusercontent.com/72284051/101297369-438d2600-37ee-11eb-91d3-fefa71b007f2.png)
