### PR TITLE
Add smooth caret blinking setting

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -1342,7 +1342,11 @@ function stopCaretAnimation() {
 
 function startCaretAnimation() {
   if (caretAnimating === false) {
-    $("#caret").css("animation-name", "caretFlash");
+    if (config.smoothCaret) {
+      $("#caret").css("animation-name", "caretFlashSmooth");
+    } else {
+      $("#caret").css("animation-name", "caretFlashHard");
+    }
     caretAnimating = true;
   }
 }

--- a/src/js/userconfig.js
+++ b/src/js/userconfig.js
@@ -972,11 +972,21 @@ function setWordCount(wordCount, nosave) {
 function setSmoothCaret(mode, nosave) {
   config.smoothCaret = mode;
   if (!nosave) saveConfigToCookie();
+  if (mode) {
+    $("#caret").css("animation-name", "caretFlashSmooth");
+  } else {
+    $("#caret").css("animation-name", "caretFlashHard");
+  }
 }
 
 function toggleSmoothCaret() {
   config.smoothCaret = !config.smoothCaret;
   saveConfigToCookie();
+  if (config.smoothCaret) {
+    $("#caret").css("animation-name", "caretFlashSmooth");
+  } else {
+    $("#caret").css("animation-name", "caretFlashHard");
+  }
 }
 
 //startgraphsatzero

--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -994,7 +994,7 @@ a:hover {
 #caret {
   height: 1.5rem;
   background: var(--caret-color);
-  animation-name: caretFlash;
+  animation-name: caretFlashSmooth;
   /* animation-timing-function: cubic-bezier(0.455, 0.03, 0.515, 0.955); */
   animation-iteration-count: infinite;
   animation-duration: 1s;
@@ -1079,13 +1079,25 @@ a:hover {
   }
 }
 
-@keyframes caretFlash {
+@keyframes caretFlashSmooth {
   0%,
   100% {
     opacity: 0;
   }
 
   50% {
+    opacity: 1;
+  }
+}
+
+@keyframes caretFlashHard {
+  0%,
+  50% {
+    opacity: 0;
+  }
+
+  51%,
+  100% {
     opacity: 1;
   }
 }


### PR DESCRIPTION
Hi!

I found the default smooth version too distracting, so I made this! I also think the non-smooth version fits better with the "block" caret style.
I based the setting off of the existing "smooth caret" setting, hopefully everything is covered!

There's 2 parts where I'm not sure if I what I did is optimal:

* [script.js](https://github.com/SeerLite/monkeytype/blob/3a1a31983ed18fe92e16f64ae7ad068fd400f01a/src/js/script.js#L1345-L1349)
* [userconfig.js](https://github.com/SeerLite/monkeytype/blob/3a1a31983ed18fe92e16f64ae7ad068fd400f01a/src/js/userconfig.js#L984-L1002)

Let me know if I should change anything in either of those!

Also, the prettierc pre-commit hook corrected a lot of formatting mistakes in most of the files I edited, but they weren't related to my changes at all. I disabled it for the PR so that it didn't make too much noise in the diffs. Consider running it on all files in the main branch to clean those up ;)

Finally, thanks for making monkeytype! It's the best one!