### PR TITLE
Have Escape always close command line/leaderboard

### DIFF
--- a/src/js/commandline.js
+++ b/src/js/commandline.js
@@ -1766,17 +1766,17 @@ $("#commandLine input").keyup((e) => {
 $(document).ready((e) => {
   $(document).keydown((event) => {
     //escape
-    if (
-      (event.keyCode == 27 && !config.swapEscAndTab) ||
-      (event["keyCode"] == 9 && config.swapEscAndTab)
-    ) {
+    if (event.keyCode == 27 || (event.keyCode == 9 && config.swapEscAndTab)) {
       event.preventDefault();
       if (!$("#leaderboardsWrapper").hasClass("hidden")) {
         //maybe add more condition for closing other dialogs in the future as well
         event.preventDefault();
         hideLeaderboards();
         return;
-      } else if ($("#commandLineWrapper").hasClass("hidden")) {
+      } else if (
+        $("#commandLineWrapper").hasClass("hidden") &&
+        (event.keyCode == 9 || !config.swapEscAndTab)
+      ) {
         if (config.singleListCommandLine == "on")
           useSingleListCommandLine(false);
         else currentCommands = [commands];

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -4565,7 +4565,8 @@ function handleTab(event) {
     !$(".pageLogin").hasClass("active") &&
     !resultCalculating &&
     $("#commandLineWrapper").hasClass("hidden") &&
-    $("#simplePopupWrapper").hasClass("hidden")
+    $("#simplePopupWrapper").hasClass("hidden") &&
+    $("#leaderboardsWrapper").hasClass("hidden")
   ) {
     event.preventDefault();
     if ($(".pageTest").hasClass("active")) {


### PR DESCRIPTION
Hi!
It was really annoying to not be able to close the command line with Escape when using swap escape/tab. This makes it so Escape always closes it no matter the setting. Tab behavior unchanged.