### PR TITLE
Ignore keys with Alt modifier

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -4936,6 +4936,7 @@ function handleAlpha(event) {
   if (/Numpad/.test(event.key)) return;
   if (/Volume/.test(event.key)) return;
   if (event.ctrlKey) return;
+  if (event.altKey) return;
   if (event.metaKey) return;
   event = emulateLayout(event);
 


### PR DESCRIPTION
Hi!
Firefox uses Alt for a number of shortcuts, like switching tabs with Alt + N. This makes it so these shortcuts don't start the test.