### PR TITLE
Fixed typo in java language

### DIFF
--- a/static/languages/code_java.json
+++ b/static/languages/code_java.json
@@ -26,7 +26,7 @@
         "implements",
         "import",
         "instanceof",
-        "instanceofinterface",
+        "interface",
         "long",
         "native",
         "new",


### PR DESCRIPTION
Replaced "instanceofinterface" with "interface" in code_java.json

"instanceofinterface" isn't a term, and I'm assuming that it's supposed to be "interface" since "instanceof" is the line directly before.
