### PR TITLE
Removed arrows in firefox in every input field type number

### DIFF
--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -70,6 +70,10 @@ input[type="number"]::-webkit-outer-spin-button {
   margin: 0;
 }
 
+input[type="number"] {
+  -moz-appearance: textfield;
+}
+
 .colorPicker {
   text-align: center;
   will-change: transform;


### PR DESCRIPTION
Changed from this  
![image](https://user-images.githubusercontent.com/69385502/103442429-4d237580-4c56-11eb-8746-5061155cadbb.png)

to this

![image](https://user-images.githubusercontent.com/69385502/103442452-92e03e00-4c56-11eb-8957-2c06e51ba43c.png)

in Firefox, in every other browser it was already done.

