### PR TITLE
Ignore Alt only modifier on Linux

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -4999,7 +4999,11 @@ function handleAlpha(event) {
   if (/F\d+/.test(event.key)) return;
   if (/Numpad/.test(event.key)) return;
   if (/Volume/.test(event.key)) return;
-  if (event.ctrlKey && !event.altKey) return;
+  if (
+    event.ctrlKey != event.altKey &&
+    (event.ctrlKey || /Linux/.test(window.navigator.platform))
+  )
+    return;
   if (event.metaKey) return;
   event = emulateLayout(event);
 


### PR DESCRIPTION
Not sure why I [ask](https://github.com/Miodec/monkeytype/pull/751#issuecomment-757552309) if I'm gonna end up making a PR anyway :p

`!=` so it allows when both modifiers are pressed together

It was originally a one-liner but the formatter split it up like this. Not a fan of how it looks but I'm not sure what the Javascript formatting standards are.