### PR TITLE
Add "update live stats on keypress" option

### DIFF
--- a/src/js/commandline.js
+++ b/src/js/commandline.js
@@ -197,6 +197,15 @@ let commands = {
       },
     },
     {
+      id: "changeUpdateLiveStatOnKeypress",
+      display: "Change update live stats on keypress...",
+      subgroup: true,
+      exec: () => {
+        currentCommands.push(commandsUpdateLiveStatOnKeypress);
+        showCommandLine();
+      },
+    },
+    {
       id: "toggleTimerBar",
       display: "Toggle timer display",
       exec: () => {
@@ -1059,6 +1068,40 @@ let commandsMinAcc = {
       exec: (input) => {
         setMinAccCustom(input);
         setMinAcc("custom");
+      },
+    },
+  ],
+};
+
+let commandsUpdateLiveStatOnKeypress = {
+  title: "Change update live stats on keypress...",
+  list: [
+    {
+      id: "changeUpdateLiveStatOnKeypressOff",
+      display: "off",
+      exec: () => {
+        setUpdateLiveStatOnKeypress("off");
+      },
+    },
+    {
+      id: "changeUpdateLiveStatOnKeypressWpm",
+      display: "wpm",
+      exec: () => {
+        setUpdateLiveStatOnKeypress("wpm");
+      },
+    },
+    {
+      id: "changeUpdateLiveStatOnKeypressAcc",
+      display: "acc",
+      exec: () => {
+        setUpdateLiveStatOnKeypress("acc");
+      },
+    },
+    {
+      id: "changeUpdateLiveStatOnKeypressBoth",
+      display: "both",
+      exec: () => {
+        setUpdateLiveStatOnKeypress("both");
       },
     },
   ],

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -4617,6 +4617,27 @@ $(document).keydown(function (event) {
   }
 
   handleAlpha(event);
+
+  if (
+    config.updateLiveStatOnKeypress == "wpm" ||
+    config.updateLiveStatOnKeypress == "both"
+  ) {
+    let wpmAndRaw = liveWpmAndRaw();
+    updateLiveWpm(wpmAndRaw.wpm, wpmAndRaw.raw);
+  }
+
+  if (
+    config.updateLiveStatOnKeypress == "acc" ||
+    config.updateLiveStatOnKeypress == "both"
+  ) {
+    let acc = Misc.roundTo2(
+      (accuracyStats.correct /
+        (accuracyStats.correct + accuracyStats.incorrect)) *
+        100
+    );
+
+    updateLiveAcc(acc);
+  }
 });
 
 function handleTab(event) {

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -82,6 +82,10 @@ settingsGroups.showLiveWpm = new SettingsGroup(
   }
 );
 settingsGroups.showLiveAcc = new SettingsGroup("showLiveAcc", setShowLiveAcc);
+settingsGroups.updateLiveStatOnKeypress = new SettingsGroup(
+  "updateLiveStatOnKeypress",
+  setUpdateLiveStatOnKeypress
+);
 settingsGroups.showTimerProgress = new SettingsGroup(
   "showTimerProgress",
   setShowTimerProgress

--- a/src/js/userconfig.js
+++ b/src/js/userconfig.js
@@ -74,6 +74,7 @@ let defaultConfig = {
   minAcc: "off",
   minAccCustom: 90,
   showLiveAcc: false,
+  updateLiveStatOnKeypress: "off",
 };
 
 let cookieConfig = null;
@@ -673,6 +674,14 @@ function setShowLiveAcc(live, nosave) {
 function toggleShowLiveAcc() {
   config.showLiveAcc = !config.showLiveAcc;
   saveConfigToCookie();
+}
+
+function setUpdateLiveStatOnKeypress(stat, nosave) {
+  if (stat == null || stat == undefined || stat == true || stat == false) {
+    stat = "off";
+  }
+  config.updateLiveStatOnKeypress = stat;
+  if (!nosave) saveConfigToCookie();
 }
 
 function setHighlightMode(mode, nosave) {
@@ -1525,6 +1534,7 @@ function applyConfig(configObj) {
     setSmoothLineScroll(configObj.smoothLineScroll, true);
     setShowLiveWpm(configObj.showLiveWpm, true);
     setShowLiveAcc(configObj.showLiveAcc, true);
+    setUpdateLiveStatOnKeypress(configObj.updateLiveStatOnKeypress, true);
     setShowTimerProgress(configObj.showTimerProgress, true);
     setAlwaysShowDecimalPlaces(configObj.alwaysShowDecimalPlaces, true);
     setAlwaysShowWordsHistory(configObj.alwaysShowWordsHistory, true);

--- a/static/index.html
+++ b/static/index.html
@@ -2938,6 +2938,47 @@
                   </div>
                 </div>
               </div>
+              <div class="section updateLiveStatOnKeypress">
+                <h1>update live stats on keypress</h1>
+                <div class="text">
+                  Update live stats immediately on keypress instead of only on
+                  each second that passes on the timer.
+                </div>
+                <div class="buttons">
+                  <div
+                    class="button"
+                    updateLiveStatOnKeypress="off"
+                    tabindex="0"
+                    onclick="this.blur();"
+                  >
+                    off
+                  </div>
+                  <div
+                    class="button"
+                    updateLiveStatOnKeypress="wpm"
+                    tabindex="0"
+                    onclick="this.blur();"
+                  >
+                    wpm
+                  </div>
+                  <div
+                    class="button"
+                    updateLiveStatOnKeypress="acc"
+                    tabindex="0"
+                    onclick="this.blur();"
+                  >
+                    acc
+                  </div>
+                  <div
+                    class="button"
+                    updateLiveStatOnKeypress="both"
+                    tabindex="0"
+                    onclick="this.blur();"
+                  >
+                    both
+                  </div>
+                </div>
+              </div>
               <div class="section showTimerProgress">
                 <h1>timer/progress</h1>
                 <div class="text">


### PR DESCRIPTION
I'm kind of verbose with my naming so this option is a bit long. Let me know if it's too long/unreadable.

I'm not sure about
```javascript
if (stat == null || stat == undefined || stat == true || stat == false)
```
but I saw all kinds of comparisons on other options so I put all of them to be sure.
This may be a dumb question but is there any specific reason these options might end up being set to `undefined` or anything that isn't their config values?