### PR TITLE
Missing --error-extra-color for carbon.css

### DIFF
--- a/static/themes/carbon.css
+++ b/static/themes/carbon.css
@@ -5,7 +5,7 @@
   --sub-color: #616161;
   --text-color: #f5e6c8;
   --error-color: #e72d2d;
-  --colorful-error-color: #b62828;
-  --colorful-error-color: #a5e72d;
-  --colorful-error-extra-color: #74a120;
+  --error-extra-color: #7e2a33;
+  --colorful-error-color: #e72d2d;
+  --colorful-error-extra-color: #7e2a33;
 }


### PR DESCRIPTION
Added the missing error extra color, without this it defaults to the text color. 
Also changing the colorful variants to match.

![image](https://user-images.githubusercontent.com/71089234/104321357-6be9fd80-54db-11eb-8e64-18830b676984.png)
