### PR TITLE
Fix: Timer not visible with new stealth theme #847

### DIFF
--- a/static/themes/stealth.css
+++ b/static/themes/stealth.css
@@ -1,12 +1,17 @@
-:root{
-        --bg-color: #010203;
-        --main-color: #383e42;
-        --caret-color: #e25303;
-        --sub-color: #5e676e;
-        --text-color: #383e42;
-        --error-color: #e25303;
-        --error-extra-color: #73280c;
-        --colorful-error-color: #e25303;
-        --colorful-error-extra-color: #73280c;
-}       
-#menu .icon-button:nth-child(4){color:#e25303}
+:root {
+  --bg-color: #010203;
+  --main-color: #383e42;
+  --caret-color: #e25303;
+  --sub-color: #5e676e;
+  --text-color: #383e42;
+  --error-color: #e25303;
+  --error-extra-color: #73280c;
+  --colorful-error-color: #e25303;
+  --colorful-error-extra-color: #73280c;
+}
+#menu .icon-button:nth-child(4) {
+  color: #e25303;
+}
+#timerNumber {
+  color: #5e676e;
+}


### PR DESCRIPTION
### **Fix: Timer not visible with new stealth theme**  #847
File was also formatted with prettier.

**Stealth theme before**
![image](https://user-images.githubusercontent.com/71089234/104773665-50962100-576d-11eb-9819-cff03e106664.png)

**Stealth theme after**
![image](https://user-images.githubusercontent.com/71089234/104773759-76232a80-576d-11eb-812a-e034713c417d.png)