### PR TITLE
Fixing a typo in a german quote

### DIFF
--- a/static/quotes/german.json
+++ b/static/quotes/german.json
@@ -20,7 +20,7 @@
   ],
   "quotes": [
     {
-      "text": "\"Das Internet der Dinge\", sagte Ogarew, \"ist ein Thema, das uns hier ganz besonders beschäftigt. Denn mit dem Web 4.0 kommt das Internet überallhin. Von Autos über TV bis hin zu Kinderspielzeug. Heute schon gibt es fünfzehn Milliarden vernetzte Geräte. 2020 wird es fünfzig Milliarden geben. Da muss alles von vornherein sicher sein. So wie Microsoft das früher gemacht hat, geht es heute nicht mehr. Erst mal auf den Markt bringen und dann nachträglich das Feuer Löschen.\" Er lächelte durch seinen grauen Bart hindurch. \"Gott durfte das noch. Er sah, dass es gut war. Und als es doch nicht gut war, kam die Sintflut. So eine Art Neustart. Aber eine Sintflut kann sich das Internet der Dinge nicht erlauben.\"",
+      "text": "\"Das Internet der Dinge\", sagte Ogarew, \"ist ein Thema, das uns hier ganz besonders beschäftigt. Denn mit dem Web 4.0 kommt das Internet überallhin. Von Autos über TV bis hin zu Kinderspielzeug. Heute schon gibt es fünfzehn Milliarden vernetzte Geräte. 2020 wird es fünfzig Milliarden geben. Da muss alles von vornherein sicher sein. So wie Microsoft das früher gemacht hat, geht es heute nicht mehr. Erst mal auf den Markt bringen und dann nachträglich das Feuer löschen.\" Er lächelte durch seinen grauen Bart hindurch. \"Gott durfte das noch. Er sah, dass es gut war. Und als es doch nicht gut war, kam die Sintflut. So eine Art Neustart. Aber eine Sintflut kann sich das Internet der Dinge nicht erlauben.\"",
       "source": "Dark Web: Thriller, Veit Etzold",
       "length": 708,
       "id": 1

--- a/static/quotes/german.json
+++ b/static/quotes/german.json
@@ -134,7 +134,7 @@
       "id": 19
     },
     {
-      "text": "Die Jugend liebt heutzutage den Luxus. Sie hat schlechte Manieren, verachtet die Autorität, hat keinen Respekt vor älteren Leuten und quasselt, wo sie arbeiten sollte. Die jungen Leute stehen nicht mehr auf wenn ältere das Zimmer betreten. Sie widersprechen ihren Eltern, schwadronieren in der Gesellschaft, verschlingen bei Tische die Süßspeisen, legen die Beine übereinander und tyrannisieren ihr Lehrer.",
+      "text": "Die Jugend liebt heutzutage den Luxus. Sie hat schlechte Manieren, verachtet die Autorität, hat keinen Respekt vor älteren Leuten und quasselt, wo sie arbeiten sollte. Die jungen Leute stehen nicht mehr auf wenn ältere das Zimmer betreten. Sie widersprechen ihren Eltern, schwadronieren in der Gesellschaft, verschlingen bei Tische die Süßspeisen, legen die Beine übereinander und tyrannisieren ihre Lehrer.",
       "source": "Sokrates",
       "length": 406,
       "id": 20


### PR DESCRIPTION
Adding a language or a theme? Make sure to edit the `_list.json` file as well, otherwise, it will not work!
Didn't add a language or theme

Please reference any issues related to your pull request.
(No GitHub issue)

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.
Not a theme.

(Yes, I know I may be fulfilling a stereotype here...)

### Fixed typos:
a6c1ae8: "löschen" is a verb and should therefore not be capitalized in German grammar.
08b236c: "ihr" is singular, "Lehrer" is plural - before, it was saying "their teachers". I checked whether the updated version is the correct version of the quote before commiting.