### PR TITLE
Fix transition on page reload

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -5634,7 +5634,21 @@ $("#wpmChart").on("mouseleave", (e) => {
   $(".wordInputAfter").remove();
 });
 
+let mappedRoutes = {
+  '/': 'pageTest',
+  '/login' : 'pageLogin',
+  '/settings' : 'pageSettings',
+  '/about' : 'pageAbout',
+  '/account': 'pageAccount',
+}
+
+function handleInitialPageClasses(el) {
+    $(el).removeClass("hidden");
+    $(el).addClass("active");
+}
+
 $(document).ready(() => {
+  handleInitialPageClasses($(".page." + mappedRoutes[window.location.pathname]));
   updateFavicon(32, 14);
   $("body").css("transition", ".25s");
   if (config.quickTab) {

--- a/static/index.html
+++ b/static/index.html
@@ -920,7 +920,7 @@
             </div>
           </div>
 
-          <div class="config">
+          <div class="config hidden">
             <div style="display: grid; grid-auto-flow: column">
               <div class="group punctuationMode">
                 <!--           <div class="title">time</div> -->
@@ -1011,7 +1011,7 @@
           </div>
         </div>
         <div id="middle">
-          <div class="page pageTest active">
+          <div class="page pageTest hidden">
             <div id="typingTest">
               <div id="capsWarning" class="hidden">
                 <i class="fas fa-lock"></i>


### PR DESCRIPTION
Fixes #863

https://github.com/Miodec/monkeytype/issues/863

When refreshing the page or going back using the browser back button on a route other than "/" you would see a flickering on the animation transition between the main page `pageTest` and the other one. This is caused because the `pageTest` is set to active by default in the html.

This PR aims to fix this behaviour by setting the `pageTest` to `hidden`  and setting the proper classes when the page is loaded.
