### PR TITLE
Add release and unstable deployment targets, to use with unstable/experimental channel

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,20 +1,40 @@
 {
-  "hosting": {
-    "public": "dist",
-    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
-    "rewrites": [
-      {
-        "source": "/privacy-policy",
-        "destination": "/privacy-policy.html"
-      },
-      {
-        "source": "**",
-        "destination": "/index.html"
-      }
-    ],
-    "cleanUrls": true,
-    "trailingSlash": false
-  }
+  "hosting": [
+    {
+      "target": "release",
+      "public": "dist",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+      "rewrites": [
+        {
+          "source": "/privacy-policy",
+          "destination": "/privacy-policy.html"
+        },
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ],
+      "cleanUrls": true,
+      "trailingSlash": false
+    },
+    {
+      "target": "unstable",
+      "public": "dist",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+      "rewrites": [
+        {
+          "source": "/privacy-policy",
+          "destination": "/privacy-policy.html"
+        },
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ],
+      "cleanUrls": true,
+      "trailingSlash": false
+    }
+  ]
   // },
   // "functions": {
   //   "predeploy": [

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "postinstall": "cd functions && npm install",
     "build": "npx gulp build",
     "start:dev": "npm run build && concurrently --kill-others \"npx gulp watch\" \"firebase serve\"",
-    "deploy:live:hosting": "npm run build && firebase deploy -P monkey-type --only hosting",
-    "deploy:live:functions": "npm run build && firebase deploy -P monkey-type --only functions",
-    "deploy:live": "npm run build && firebase deploy -P live"
+    "deploy:live:release": "npm run build && firebase deploy --only hosting:release",
+    "deploy:live:unstable": "npm run build && firebase deploy --only hosting:unstable",
+    "deploy:live:functions": "npm run build && firebase deploy --only functions"
   },
   "engines": {
     "node": "10"


### PR DESCRIPTION
So I did the research and this is how an unstable channel for non-release updates can be set up. I'd really like this to be implemented because I feel this way the actual releases would have more value and be more stable (more testing from community users, less bugs encountered by casual users). The changelog also becomes more consistent with previous versions

## Setup
1. Add a new site: Firebase console > Hosting > Advanced > Add another site
2. Set up a domain/subdomain for the site: `testing.monkeytype.com` and `unstable.monkeytype.com` are ones that I personally like. I don't think `beta` would be correct here, because it's use is more common for pre-release/ready-to-use versions. (Though you could add as many sites/targets as you like, and beta could be one of them!)
3. Set up `.firebaserc` according to `.firebaserc_example` or use `firebase use` (which I think does the same thing). I say this just in case you don't have it set up, since `package.json` has the `-P monkey-type` flag, which I removed in this PR to make it less "hardcoded"
4. Set up targets locally:
```shell
firebase target:apply hosting release <release-site-id>
firebase target:apply hosting unstable <unstable-site-id>
```
Notes:
* The deployment scripts for each channel is called `deploy:live:<channel>`. `deploy:live:functions` is still functions.
* The commands from step 4 edit `.firebaserc` and save the target to site-name linking there.

And that's about it! I'm pretty sure I didn't miss anything, All the steps are explained in more detail in the Firebase [docs](https://firebase.google.com/docs/hosting/multisites) if you want to check them out

Edit: Another good subdomain: `dev.`
