### PR TITLE
Treat every space character as trusted

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -4837,11 +4837,7 @@ $(document).keyup((event) => {
 });
 
 $(document).keydown(function (event) {
-  if (
-    !(activeFunBox == "nospace" && event.key == " ") &&
-    !event.originalEvent.isTrusted
-  )
-    return;
+  if (!(event.key == " ") && !event.originalEvent.isTrusted) return;
 
   if (!resultVisible) {
     let now = performance.now();


### PR DESCRIPTION
Related to #917. I didn't realize the space character was also manually triggered when replacing a newline.
I didn't see an easy way to handle this, so I made it ignore _any_ space character's `isTrusted`. I doubt one can cheat much with only spaces anyway.

An even better way to handle this would be to call one of the functions under `keydown` directly instead of running `trigger`, but I didn't want to mess too much with that and just get this fixed first