### PR TITLE
Adds gray night theme

### DIFF
--- a/static/themes/_list.json
+++ b/static/themes/_list.json
@@ -480,6 +480,11 @@
     "textColor": "#383e42"
   },
   {
+    "name": "gray_night",
+    "bgColor": "#1d1e20",
+    "textColor": "#d1d0c5"
+  },
+  {
     "name": "80s_after_dark",
     "bgColor": "#1B1D36",
     "textColor": "#FCA6D1"

--- a/static/themes/gray_night.css
+++ b/static/themes/gray_night.css
@@ -1,0 +1,11 @@
+:root {
+  --bg-color: #1d1e20;
+  --main-color: #76868f;
+  --caret-color: #76868f;
+  --sub-color: #646669;
+  --text-color: #d1d0c5;
+  --error-color: #ca4754;
+  --error-extra-color: #7e2a33;
+  --colorful-error-color: #ca4754;
+  --colorful-error-extra-color: #7e2a33;
+}


### PR DESCRIPTION
Adds the "gray night" theme to monkeytype. Please let me know if you have a better name for it, because I am not that good at naming themes.

Example:
![image](https://i.gyazo.com/88e9b7734597753ef70d5702f8d0fe70.png)