### PR TITLE
Better gruvbox themes

### DIFF
--- a/static/themes/_list.json
+++ b/static/themes/_list.json
@@ -182,7 +182,7 @@
   {
     "name": "gruvbox_light",
     "bgColor": "#fbf1c7",
-    "textColor": "#458588"
+    "textColor": "#3c3836"
   },
   {
     "name": "monokai",

--- a/static/themes/gruvbox_dark.css
+++ b/static/themes/gruvbox_dark.css
@@ -1,11 +1,11 @@
 :root {
-  --bg-color: #282828;
-  --main-color: #d79921;
-  --caret-color: #458588;
-  --sub-color: #b8bb26;
-  --text-color: #ebdbb2;
-  --error-color: #fb4934;
-  --error-extra-color: #cc241d;
-  --colorful-error-color: #fb4934;
-  --colorful-error-extra-color: #cc241d;
+	--bg-color: #282828;
+	--main-color: #d79921;
+	--caret-color: #fabd2f;
+	--sub-color: #665c54;
+	--text-color: #ebdbb2;
+	--error-color: #fb4934;
+	--error-extra-color: #cc241d;
+	--colorful-error-color: #cc241d;
+	--colorful-error-extra-color: #9d0006;
 }

--- a/static/themes/gruvbox_light.css
+++ b/static/themes/gruvbox_light.css
@@ -1,11 +1,11 @@
 :root {
-  --bg-color: #fbf1c7;
-  --main-color: #d79921;
-  --caret-color: #458588;
-  --sub-color: #98971a;
-  --text-color: #3c3836;
-  --error-color: #cc241d;
-  --error-extra-color: #9d0006;
-  --colorful-error-color: #cc241d;
-  --colorful-error-extra-color: #9d0006;
+	--bg-color: #fbf1c7;
+	--main-color: #689d6a;
+	--caret-color: #689d6a;
+	--sub-color: #a89984;
+	--text-color: #3c3836;
+	--error-color: #cc241d;
+	--error-extra-color: #9d0006;
+	--colorful-error-color: #cc241d;
+	--colorful-error-extra-color: #9d0006;
 }


### PR DESCRIPTION
Hey there!

I feel like the current gruvbox themes don't really match what people using gruvbox (i.e. me) want to see. The green sub-color especially looks really odd to me and not really appropriate.

In this PR you'll find my proposition for a more gruvbox-like version of both the light and the dark theme.

The dark theme ends up looking pretty similar to the default serika-dark theme, but with actual gruvbox-accurate colors.