### PR TITLE
Add button to export all results as JSON

### DIFF
--- a/src/js/db.js
+++ b/src/js/db.js
@@ -153,6 +153,26 @@ export async function db_getUserResults() {
   }
 }
 
+export async function db_exportRawUserResults() {
+  let user = firebase.auth().currentUser;
+  if (user == null) return false;
+
+  try {
+    return await db
+      .collection(`users/${user.uid}/results/`)
+      .get()
+      .then((data) => {
+        return data.docs.map((doc) => doc.data());
+      })
+      .catch((e) => {
+        throw e;
+      });
+  } catch (e) {
+    console.error(e);
+    return false;
+  }
+}
+
 export async function db_getUserHighestWpm(
   mode,
   mode2,

--- a/src/js/global-dependencies.js
+++ b/src/js/global-dependencies.js
@@ -18,6 +18,7 @@ import {
   db_saveLocalPB,
   db_getLocalTagPB,
   db_saveLocalTagPB,
+  db_exportRawUserResults,
 } from "./db";
 
 import { showBackgroundLoader, hideBackgroundLoader } from "./dom-util";

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -1020,6 +1020,25 @@ $("#settingsImportWrapper").click((e) => {
   }
 });
 
+$("#exportResultsButton").click((e) => {
+  db_exportRawUserResults().then((results) => {
+    const contents = JSON.stringify(results);
+    const filename = "monkeytype-export.json";
+
+    // Create and click element to download data as file.
+    var element = document.createElement("a");
+    element.setAttribute(
+      "href",
+      "data:text/plain;charset=utf-8," + encodeURIComponent(contents)
+    );
+    element.setAttribute("download", filename);
+    element.style.display = "none";
+    document.body.appendChild(element);
+    element.click();
+    document.body.removeChild(element);
+  });
+});
+
 $(".pageSettings .sectionGroupTitle").click((e) => {
   let group = $(e.currentTarget).attr("group");
   $(`.pageSettings .settingsGroup.${group}`)

--- a/static/index.html
+++ b/static/index.html
@@ -3037,6 +3037,20 @@
                   </div>
                 </div>
               </div>
+              <div class="section exportResults">
+                <h1>export results</h1>
+                <div class="text">Export your typing results as JSON.</div>
+                <div class="buttons">
+                  <div
+                    class="button off"
+                    id="exportResultsButton"
+                    tabindex="0"
+                    onclick="this.blur();"
+                  >
+                    export
+                  </div>
+                </div>
+              </div>
               <div class="section enableAds">
                 <h1>enable ads</h1>
                 <div class="text">


### PR DESCRIPTION
The profile page only shows the most recent 1000 results for performance reasons. Exporting all results like this would allow people to run their own visualizations/stats without hitting the DB more than once.

I simulated a file with 50k results to test the downloading functionality and it worked after a few seconds of hanging.