### PR TITLE
Disable clicks on profile icon during loading.

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -3686,10 +3686,10 @@ function accountIconLoading(truefalse) {
     $("#top #menu .account .icon").html(
       '<i class="fas fa-fw fa-spin fa-circle-notch"></i>'
     );
-    $("#top #menu .account").css("opacity", 1);
+    $("#top #menu .account").css("opacity", 1).css("pointer-events", "none");
   } else {
     $("#top #menu .account .icon").html('<i class="fas fa-fw fa-user"></i>');
-    $("#top #menu .account").css("opacity", 1);
+    $("#top #menu .account").css("opacity", 1).css("pointer-events", "auto");
   }
 }
 


### PR DESCRIPTION
If the profile button/icon is clicked while the info is loading you get an error `Missing account data. Please refresh.`

This disables clicking on that icon until the profile has finished loading.

It's easier to test this by throttling requests to "Fast 3G" in Chrome's network tab.