### PR TITLE
Enable custom font entry when changing font through the command line

### DIFF
--- a/src/js/commandline.js
+++ b/src/js/commandline.js
@@ -1658,6 +1658,18 @@ Misc.getFontsList().then((fonts) => {
       },
     });
   });
+  commandsFonts.list.push({
+    id: "setFontFamilyCustom",
+    display: "custom...",
+    input: true,
+    hover: () => {
+      previewFontFamily(config.fontFamily);
+    },
+    exec: (name) => {
+      setFontFamily(name.replace(/\s/g, "_"));
+      settingsGroups.fontFamily.updateButton();
+    },
+  });
 });
 
 let commandsFunbox = {

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -5874,7 +5874,13 @@ if (window.location.hostname === "localhost") {
 }
 
 manualRestart = true;
+
+let configLoadDone;
+let configLoadPromise = new Promise((v, x) => {
+  configLoadDone = v;
+});
 loadConfigFromCookie();
+configLoadDone();
 Misc.getReleasesFromGitHub();
 // getPatreonNames();
 
@@ -5972,6 +5978,7 @@ $(document).ready(() => {
         changePage(page);
       }
     });
+  settingsFillPromise.then(updateSettingsPage);
 });
 
 $(".scrollToTopButton").click((event) => {

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -283,18 +283,22 @@ settingsGroups.alwaysShowCPM = new SettingsGroup(
   setAlwaysShowCPM
 );
 
-fillSettingsPage();
+let settingsFillPromise = fillSettingsPage();
 
 async function fillSettingsPage() {
+  await configLoadPromise;
   refreshThemeButtons();
 
   let langGroupsEl = $(
     ".pageSettings .section.languageGroups .buttons"
   ).empty();
+  let currentLanguageGroup = await Misc.findCurrentGroup(config.language);
   Misc.getLanguageGroups().then((groups) => {
     groups.forEach((group) => {
       langGroupsEl.append(
-        `<div class="languageGroup button" group='${group.name}'>${group.name}</div>`
+        `<div class="languageGroup button${
+          currentLanguageGroup === group.name ? " active" : ""
+        }" group='${group.name}'>${group.name}</div>`
       );
     });
   });
@@ -351,11 +355,15 @@ async function fillSettingsPage() {
     });
   });
 
+  let isCustomFont = true;
   let fontsEl = $(".pageSettings .section.fontFamily .buttons").empty();
   Misc.getFontsList().then((fonts) => {
     fonts.forEach((font) => {
+      if (config.fontFamily === font.name) isCustomFont = false;
       fontsEl.append(
-        `<div class="button" style="font-family:${
+        `<div class="button${
+          config.fontFamily === font.name ? " active" : ""
+        }" style="font-family:${
           font.display !== undefined ? font.display : font.name
         }" fontFamily="${font.name.replace(/ /g, "_")}" tabindex="0"
         onclick="this.blur();">${
@@ -364,7 +372,12 @@ async function fillSettingsPage() {
       );
     });
     $(
-      '<div class="language button no-auto-handle custom" onclick="this.blur();">Custom</div>'
+      isCustomFont
+        ? `<div class="language button no-auto-handle custom active" onclick="this.blur();">Custom (${config.fontFamily.replace(
+            /_/g,
+            " "
+          )})</div>`
+        : '<div class="language button no-auto-handle custom" onclick="this.blur();">Custom</div>'
     )
       .on("click", () => {
         simplePopups.applyCustomFont.show([]);

--- a/src/js/simple-popups.js
+++ b/src/js/simple-popups.js
@@ -222,6 +222,7 @@ simplePopups.applyCustomFont = new SimplePopup(
   "Make sure you have the font installed on your computer before applying.",
   "Apply",
   (fontName) => {
+    if (fontName === "") return;
     settingsGroups.fontFamily.setValue(fontName.replace(/\s/g, "_"));
   },
   () => {}

--- a/src/js/userconfig.js
+++ b/src/js/userconfig.js
@@ -975,7 +975,7 @@ function previewFontFamily(font) {
 
 //font family
 function setFontFamily(font, nosave) {
-  if (font == undefined) {
+  if (font == undefined || font === "") {
     font = "Roboto_Mono";
   }
   config.fontFamily = font;


### PR DESCRIPTION
This allows the user to type a custom font name into the command input box then press Enter to set a custom font in the _Change font family_ command.

This also fixes an issue where the settings page does not reflect the current settings when directly accessing `/settings`.