### PR TITLE
Fix Spelling Mistake In Rust Language

### DIFF
--- a/static/languages/code_rust.json
+++ b/static/languages/code_rust.json
@@ -83,7 +83,7 @@
     "<'a>",
     "map",
     "BTreeMap",
-    "VeqDeque",
+    "VecDeque",
     "LinkedList",
     "HashSet",
     "&'static",


### PR DESCRIPTION
It's [`VecDeque`](https://doc.rust-lang.org/std/collections/struct.VecDeque.html), not `VeqDeque`. :)
