### PR TITLE
RTL languages - Punctuation

### DIFF
--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -1815,9 +1815,11 @@ key {
 
   /* a little hack for right-to-left languages */
   &.rightToLeftTest {
-    flex-direction: row-reverse;
+    //flex-direction: row-reverse; // no need for hacking 😉, CSS fully support right-to-left languages
+    direction: rtl;
     .word {
-      flex-direction: row-reverse;
+      //flex-direction: row-reverse;
+      direction: rtl;
     }
   }
   &.withLigatures {


### PR DESCRIPTION
Punctuation in right-to-left languages displayed incorrectly.

before the fix:
![image](https://user-images.githubusercontent.com/53663592/109125365-a8547e80-7754-11eb-9aee-f6017a3cf185.png)

after the fix:
![image](https://user-images.githubusercontent.com/53663592/109125149-6592a680-7754-11eb-8529-3c639eebc0e2.png)
