### PR TITLE
Removing hidden whitespace after completed quotes

### DIFF
--- a/static/quotes/english.json
+++ b/static/quotes/english.json
@@ -1334,7 +1334,7 @@
       "length": 93
     },
     {
-      "text": "In the casino, the cardinal rule is to keep them playing and to keep them coming back. The longer they play, the more they lose, and in the end, we get it all. Running a casino is like robbing a bank with no cops around. ",
+      "text": "In the casino, the cardinal rule is to keep them playing and to keep them coming back. The longer they play, the more they lose, and in the end, we get it all. Running a casino is like robbing a bank with no cops around.",
       "source": "Casino",
       "id": 224,
       "length": 221
@@ -3608,7 +3608,7 @@
       "length": 248
     },
     {
-      "text": "Now I want you to think and stop being a smart aleck. A man's attitude goes some ways - the way his life will be. Is that something you agree with? So since you agree, you must be someone who does not care about the good life. ",
+      "text": "Now I want you to think and stop being a smart aleck. A man's attitude goes some ways - the way his life will be. Is that something you agree with? So since you agree, you must be someone who does not care about the good life.",
       "source": "Mulholland Drive",
       "id": 604,
       "length": 227
@@ -4334,7 +4334,7 @@
       "length": 207
     },
     {
-      "text": "There is something about yourself that you don't know. Something that you will deny even exists, until it's too late to do anything about it. It's the only reason you get up in the morning. We share an addiction. We're approval junkies. We're all in it for the slap on the back and the gold watch. ",
+      "text": "There is something about yourself that you don't know. Something that you will deny even exists, until it's too late to do anything about it. It's the only reason you get up in the morning. We share an addiction. We're approval junkies. We're all in it for the slap on the back and the gold watch.",
       "source": "Revolver",
       "id": 725,
       "length": 298
@@ -5414,7 +5414,7 @@
       "length": 139
     },
     {
-      "text": "I had a dream. There was our world, and the world was dark because there weren't any robins, and the robins represented love. And for the longest time, there was this darkness. Then all of a sudden, thousands of robins were set free and they flew down and brought this blinding light of love. I guess it means that there is trouble until the robins come. ",
+      "text": "I had a dream. There was our world, and the world was dark because there weren't any robins, and the robins represented love. And for the longest time, there was this darkness. Then all of a sudden, thousands of robins were set free and they flew down and brought this blinding light of love. I guess it means that there is trouble until the robins come.",
       "source": "Blue Velvet",
       "id": 907,
       "length": 355
@@ -5450,7 +5450,7 @@
       "length": 507
     },
     {
-      "text": "One thing I've learned in the last seven years: in every game and con there's always an opponent, and there's always a victim. The trick is to know when you're the latter, so you can become the former. ",
+      "text": "One thing I've learned in the last seven years: in every game and con there's always an opponent, and there's always a victim. The trick is to know when you're the latter, so you can become the former.",
       "source": "Revolver",
       "id": 913,
       "length": 202
@@ -6014,7 +6014,7 @@
       "length": 192
     },
     {
-      "text": "The terminator wouldn't stop, it would never leave him. It would never hurt him or shout at him or get drunk and hit him or say it was too busy to spend time with him. And it would die to protect him. Of all the would-be fathers that came over the years, this thing, this machine, was the only thing that measured up. In an insane world, it was the sanest choice. ",
+      "text": "The terminator wouldn't stop, it would never leave him. It would never hurt him or shout at him or get drunk and hit him or say it was too busy to spend time with him. And it would die to protect him. Of all the would-be fathers that came over the years, this thing, this machine, was the only thing that measured up. In an insane world, it was the sanest choice.",
       "source": "Terminator 2: Judgment Day",
       "id": 1009,
       "length": 364
@@ -7934,7 +7934,7 @@
       "length": 310
     },
     {
-      "text": "Let's face it: there are tons of things in your home and life that you don't use, need, or even particularly want. Whether you realize it or not, this clutter creates indecision and distractions, consuming attention and making unfettered happiness a real chore. ",
+      "text": "Let's face it: there are tons of things in your home and life that you don't use, need, or even particularly want. Whether you realize it or not, this clutter creates indecision and distractions, consuming attention and making unfettered happiness a real chore.",
       "source": "The 4-Hour Workweek",
       "id": 1335,
       "length": 262
@@ -9788,7 +9788,7 @@
       "length": 170
     },
     {
-      "text": "Has it been five years? Six? It seems like a lifetime, the kind of peak that never comes again. San Francisco in the middle sixties was a very special time and place to be a part of. But no explanation, no mix of words or music or memories can touch that sense of knowing that you were there and alive in that corner of time and the world. Whatever it meant. ",
+      "text": "Has it been five years? Six? It seems like a lifetime, the kind of peak that never comes again. San Francisco in the middle sixties was a very special time and place to be a part of. But no explanation, no mix of words or music or memories can touch that sense of knowing that you were there and alive in that corner of time and the world. Whatever it meant.",
       "source": "Fear and Loathing in Las Vegas",
       "id": 1649,
       "length": 359
@@ -11180,7 +11180,7 @@
       "length": 94
     },
     {
-      "text": "I will need my spectacles and a clear head. Today I broke my rules and I drank vodka. Tomorrow I will translate it, and then I will bring what I've done to your home. ",
+      "text": "I will need my spectacles and a clear head. Today I broke my rules and I drank vodka. Tomorrow I will translate it, and then I will bring what I've done to your home.",
       "source": "Eastern Promises",
       "id": 1882,
       "length": 167
@@ -13520,7 +13520,7 @@
       "length": 323
     },
     {
-      "text": "My name is Turkish. Funny name for an Englishman, I know. My parents to be were on the same plane when it crashed. That's how they met. They named me after the name of the plane. Not many people are named after a plane crash. ",
+      "text": "My name is Turkish. Funny name for an Englishman, I know. My parents to be were on the same plane when it crashed. That's how they met. They named me after the name of the plane. Not many people are named after a plane crash.",
       "source": "Snatch",
       "id": 2277,
       "length": 226
@@ -13790,7 +13790,7 @@
       "length": 317
     },
     {
-      "text": "I said that I would see you because I had heard that you were a serious man. A man to be treated with respect but I must say no to you and I will give you my reasons. It's true, I have a lot of friends in politics. But they wouldn't be so friendly if they knew my business was drugs instead of gambling which they consider a harmless vice, but drugs, that's a dirty business. ",
+      "text": "I said that I would see you because I had heard that you were a serious man. A man to be treated with respect but I must say no to you and I will give you my reasons. It's true, I have a lot of friends in politics. But they wouldn't be so friendly if they knew my business was drugs instead of gambling which they consider a harmless vice, but drugs, that's a dirty business.",
       "source": "The Godfather",
       "id": 2322,
       "length": 376
@@ -14234,7 +14234,7 @@
       "length": 231
     },
     {
-      "text": "Music finds a comfortable parallel with that of human language. Much as language has words, sentences, and stories, music has tones, melodies, and songs. ",
+      "text": "Music finds a comfortable parallel with that of human language. Much as language has words, sentences, and stories, music has tones, melodies, and songs.",
       "source": "Civilization IV",
       "id": 2397,
       "length": 154
@@ -14522,7 +14522,7 @@
       "length": 203
     },
     {
-      "text": "If there is one thing the history of evolution has taught us it's that life will not be contained. Life breaks free, expands to new territory, and crashes through barriers, painfully, maybe even dangerously. ",
+      "text": "If there is one thing the history of evolution has taught us it's that life will not be contained. Life breaks free, expands to new territory, and crashes through barriers, painfully, maybe even dangerously.",
       "source": "Jurassic Park",
       "id": 2445,
       "length": 208
@@ -16610,7 +16610,7 @@
       "length": 176
     },
     {
-      "text": "The chemistry of an element is determined by the manner in which its electrons are arranged in the atom. Such arrangements are the basis of the modern periodic classification of the elements: the Periodic Table. ",
+      "text": "The chemistry of an element is determined by the manner in which its electrons are arranged in the atom. Such arrangements are the basis of the modern periodic classification of the elements: the Periodic Table.",
       "source": "Structure and Bonding (Basic Concepts in Chemistry)",
       "id": 2802,
       "length": 212
@@ -17438,7 +17438,7 @@
       "length": 336
     },
     {
-      "text": "A little boy went out to play. When he opened his door, he saw the world. As he passed through the doorway, he caused a reflection. Evil was born, and followed the boy. ",
+      "text": "A little boy went out to play. When he opened his door, he saw the world. As he passed through the doorway, he caused a reflection. Evil was born, and followed the boy.",
       "source": "Inland Empire",
       "id": 2940,
       "length": 169
@@ -18110,7 +18110,7 @@
       "length": 72
     },
     {
-      "text": "I still see things that are not here. I just choose not to acknowledge them. Like a diet of the mind, I just choose not to indulge certain appetites; like my appetite for patterns; perhaps my appetite to imagine and to dream. ",
+      "text": "I still see things that are not here. I just choose not to acknowledge them. Like a diet of the mind, I just choose not to indulge certain appetites; like my appetite for patterns; perhaps my appetite to imagine and to dream.",
       "source": "A Beautiful Mind",
       "id": 3055,
       "length": 226
@@ -18404,7 +18404,7 @@
       "length": 375
     },
     {
-      "text": "But suddenly, I viddied that thinking was for the gloopy ones, and that the oomny ones use like, inspiration and what Bog sends. Now it was lovely music that came into my aid. There was a window open with the stereo on, and I viddied right at once what to do. ",
+      "text": "But suddenly, I viddied that thinking was for the gloopy ones, and that the oomny ones use like, inspiration and what Bog sends. Now it was lovely music that came into my aid. There was a window open with the stereo on, and I viddied right at once what to do.",
       "source": "A Clockwork Orange",
       "id": 3105,
       "length": 260
@@ -19352,7 +19352,7 @@
       "length": 91
     },
     {
-      "text": "What should have been swift revenge turned into an all out war. The City of God was divided. You couldn't go from one section to the other, not even to visit a relative. The cops considered anyone living in the slum a hoodlum. People got used to living in Vietnam, and more and more volunteers signed up to die. ",
+      "text": "What should have been swift revenge turned into an all out war. The City of God was divided. You couldn't go from one section to the other, not even to visit a relative. The cops considered anyone living in the slum a hoodlum. People got used to living in Vietnam, and more and more volunteers signed up to die.",
       "source": "City of God (Cidade de Deus, Brazil)",
       "id": 3263,
       "length": 312
@@ -21164,7 +21164,7 @@
       "length": 220
     },
     {
-      "text": "That's Tommy. He tells people he was named after a gun, but I know he was really named after a famous 19th century ballet dancer. ",
+      "text": "That's Tommy. He tells people he was named after a gun, but I know he was really named after a famous 19th century ballet dancer.",
       "source": "Snatch",
       "id": 3569,
       "length": 130
@@ -23048,7 +23048,7 @@
       "length": 152
     },
     {
-      "text": "The beginner writes just twenty pieces. The professional writes three times what's needed, rewrites, discards, rewrites some more, then finally settles on the twenty which work best for that specific audience. ",
+      "text": "The beginner writes just twenty pieces. The professional writes three times what's needed, rewrites, discards, rewrites some more, then finally settles on the twenty which work best for that specific audience.",
       "source": "Comedy Writing Secrets",
       "id": 3884,
       "length": 210
@@ -23444,7 +23444,7 @@
       "length": 176
     },
     {
-      "text": "You found paradise in America. You had a good trade, made a good living, the police protected you and there were courts of law and you didn't need a friend like me. But, now you come to me and you say, \"Don Corleone, give me justice.\" But you don't ask with respect. You don't offer friendship. You don't even think to call me Godfather. ",
+      "text": "You found paradise in America. You had a good trade, made a good living, the police protected you and there were courts of law and you didn't need a friend like me. But, now you come to me and you say, \"Don Corleone, give me justice.\" But you don't ask with respect. You don't offer friendship. You don't even think to call me Godfather.",
       "source": "The Godfather",
       "id": 3950,
       "length": 338
@@ -23798,7 +23798,7 @@
       "length": 133
     },
     {
-      "text": "Facts can be thought of as objective or subjective. Things and events are objective facts. A subjective fact is one that is limited to the subject experiencing it. Establishing the reality of subjective facts depends entirely on the trustworthiness of those who claim to be experiencing them. ",
+      "text": "Facts can be thought of as objective or subjective. Things and events are objective facts. A subjective fact is one that is limited to the subject experiencing it. Establishing the reality of subjective facts depends entirely on the trustworthiness of those who claim to be experiencing them.",
       "source": "Being Logical: A Guide to Good Thinking",
       "id": 4009,
       "length": 293
@@ -26678,7 +26678,7 @@
       "length": 275
     },
     {
-      "text": "You have to wonder: how do the machines know what Tasty Wheat tasted like? Maybe they got it wrong. Maybe what I think Tasty Wheat tasted like actually tasted like oatmeal, or tuna fish. That makes you wonder about a lot of things. You take chicken, for example: maybe they couldn't figure out what to make chicken taste like, which is why chicken tastes like everything. ",
+      "text": "You have to wonder: how do the machines know what Tasty Wheat tasted like? Maybe they got it wrong. Maybe what I think Tasty Wheat tasted like actually tasted like oatmeal, or tuna fish. That makes you wonder about a lot of things. You take chicken, for example: maybe they couldn't figure out what to make chicken taste like, which is why chicken tastes like everything.",
       "source": "The Matrix",
       "id": 4492,
       "length": 372
@@ -28460,7 +28460,7 @@
       "length": 688
     },
     {
-      "text": "The beginner writes just twenty pieces. The professional writes three times what's needed, as many as sixty different bits, keeps trying them out on small groups (but never your own family), rewrites discards, rewrites some more, then finally settles on the twenty which work best for that specific audience. ",
+      "text": "The beginner writes just twenty pieces. The professional writes three times what's needed, as many as sixty different bits, keeps trying them out on small groups (but never your own family), rewrites discards, rewrites some more, then finally settles on the twenty which work best for that specific audience.",
       "source": "Comedy Writing Secrets",
       "id": 4793,
       "length": 309


### PR DESCRIPTION
I noticed that when typing certain quotes in monkeytype, completing the
quote with punctuation wouldn't bring me to the 'finished' screen due
to an extra, hidden whitespace. This PR removes the white spaces from the
english quotes.