### PR TITLE
Opposite Shift, update key lists to add their symbols

### DIFF
--- a/src/js/shift-tracker.js
+++ b/src/js/shift-tracker.js
@@ -39,6 +39,13 @@ let leftSideKeys = [
   "KeyX",
   "KeyC",
   "KeyV",
+  
+  "Backquote",
+  "Digit1",
+  "Digit2",
+  "Digit3",
+  "Digit4",
+  "Digit5",
 ];
 
 let rightSideKeys = [
@@ -54,6 +61,20 @@ let rightSideKeys = [
 
   "KeyN",
   "KeyM",
+  
+  "Digit7",
+  "Digit8",
+  "Digit9",
+  "Digit0",
+  
+  "Backslash",
+  "BracketLeft",
+  "BracketRight",
+  "Semicolon",
+  "Quote",
+  "Comma",
+  "Period",
+  "Slash",
 ];
 
 export function isUsingOppositeShift(event) {

--- a/static/index.html
+++ b/static/index.html
@@ -1943,11 +1943,12 @@
                 <div class="text">
                   This mode will force you to use opposite
                   <key>shift</key>
-                  keys for capitalisation. Using an incorrect one will count as
+                  keys for shifting. Using an incorrect one will count as
                   an error. This feature ignores keys in locations
-                  <key>B</key>
+                  <key>B</key>,
+                  <key>Y</key>,
                   and
-                  <key>Y</key>
+                  <key>^</key>
                   because many people use the other hand for those keys.
                 </div>
                 <div class="buttons">


### PR DESCRIPTION
* update key list to add symbols

Added the symbols that are on the right side of the keyboard and the symbols that are on the left side to their appropriate lists. Left the `^` key because it is neutral.

* Edit opposite shift text

Not all languages use shift for capitalization, so with the added symbols, it doesn't make a lot of sense to say 'capitalisation', so I turned it to 'shifting'.
