### PR TITLE
Made it so funbox gets temporarily disabled when not taking a test

### DIFF
--- a/src/js/commandline-lists.js
+++ b/src/js/commandline-lists.js
@@ -126,9 +126,8 @@ let commandsFunbox = {
       id: "changeFunboxNone",
       display: "none",
       exec: () => {
-        if (Funbox.activate("none", null)) {
-          TestLogic.restart();
-        }
+        Funbox.setFunbox("none", null);
+        TestLogic.restart();
       },
     },
   ],
@@ -140,9 +139,8 @@ Misc.getFunboxList().then((funboxes) => {
       id: "changeFunbox" + funbox.name,
       display: funbox.name.replace(/_/g, " "),
       exec: () => {
-        if (Funbox.activate(funbox.name, funbox.type)) {
-          TestLogic.restart();
-        }
+        Funbox.setFunbox(funbox.name, funbox.type);
+        TestLogic.restart();
       },
     });
   });

--- a/src/js/commandline-lists.js
+++ b/src/js/commandline-lists.js
@@ -126,8 +126,9 @@ let commandsFunbox = {
       id: "changeFunboxNone",
       display: "none",
       exec: () => {
-        Funbox.setFunbox("none", null);
-        TestLogic.restart();
+        if (Funbox.setFunbox("none", null)) {
+          TestLogic.restart();
+        }
       },
     },
   ],
@@ -139,8 +140,9 @@ Misc.getFunboxList().then((funboxes) => {
       id: "changeFunbox" + funbox.name,
       display: funbox.name.replace(/_/g, " "),
       exec: () => {
-        Funbox.setFunbox(funbox.name, funbox.type);
-        TestLogic.restart();
+        if (Funbox.setFunbox(funbox.name, funbox.type)) {
+          TestLogic.restart();
+        }
       },
     });
   });

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -616,7 +616,7 @@ $(".pageSettings .section.discordIntegration #unlinkDiscordButton").click(
 $(document).on("click", ".pageSettings .section.funbox .button", (e) => {
   let funbox = $(e.currentTarget).attr("funbox");
   let type = $(e.currentTarget).attr("type");
-  Funbox.activate(funbox, type);
+  Funbox.setFunbox(funbox, type);
   setActiveFunboxButton();
 });
 

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -420,7 +420,7 @@ export function updateDiscordSection() {
 function setActiveFunboxButton() {
   $(`.pageSettings .section.funbox .button`).removeClass("active");
   $(
-    `.pageSettings .section.funbox .button[funbox='${Funbox.active}']`
+    `.pageSettings .section.funbox .button[funbox='${Funbox.funboxSaved}']`
   ).addClass("active");
 }
 

--- a/src/js/test/funbox.js
+++ b/src/js/test/funbox.js
@@ -9,6 +9,8 @@ import * as Settings from "./settings";
 export let active = "none";
 let memoryTimer = null;
 let memoryInterval = null;
+let currentFunbox = "none";
+let currentMode = null;
 
 function showMemoryTimer() {
   $("#typingTest #memoryTimer").stop(true, true).animate(
@@ -71,12 +73,9 @@ export function toggleScript(...params) {
 }
 
 export async function activate(funbox, mode) {
-  if (TestLogic.active || TestUI.resultVisible) {
-    Notifications.add(
-      "You can only change the funbox before starting a test.",
-      0
-    );
-    return false;
+  if (funbox === undefined) {
+    funbox = currentFunbox;
+    mode = currentMode;
   }
   if (Misc.getCurrentLanguage().ligatures) {
     if (funbox == "choo_choo" || funbox == "earthquake") {
@@ -153,12 +152,16 @@ export async function activate(funbox, mode) {
     active = funbox;
   }
 
+  TestUI.updateModesNotice();
+  return true;
+}
+export function setFunbox(funbox, mode) {
+  currentFunbox = funbox;
+  currentMode = mode;
   if (funbox !== "layoutfluid" || mode !== "script") {
     if (Config.layout !== Config.savedLayout) {
       UpdateConfig.setLayout(Config.savedLayout);
       Settings.groups.layout.updateButton();
     }
   }
-  TestUI.updateModesNotice();
-  return true;
 }

--- a/src/js/test/funbox.js
+++ b/src/js/test/funbox.js
@@ -73,9 +73,8 @@ export function toggleScript(...params) {
 }
 
 export async function activate(funbox, mode) {
-  if (funbox === undefined) {
+  if (funbox === undefined || funbox === null) {
     funbox = funboxSaved;
-    mode = modeSaved;
   }
   if (Misc.getCurrentLanguage().ligatures) {
     if (funbox == "choo_choo" || funbox == "earthquake") {
@@ -95,8 +94,12 @@ export async function activate(funbox, mode) {
 
   $("#wordsWrapper").removeClass("hidden");
   // }
-
-  if (mode === null || mode === undefined) {
+  if (funbox === "none" && mode === undefined) {
+    mode = null;
+  } else if (
+    (funbox !== "none" && mode === undefined) ||
+    (funbox !== "none" && mode === null)
+  ) {
     let list = await Misc.getFunboxList();
     mode = list.filter((f) => f.name === funbox)[0].type;
   }

--- a/src/js/test/funbox.js
+++ b/src/js/test/funbox.js
@@ -162,7 +162,15 @@ export async function activate(funbox, mode) {
   return true;
 }
 export function setFunbox(funbox, mode) {
+  if (TestLogic.active || TestUI.resultVisible) {
+    Notifications.add(
+      "You can only change the funbox before starting a test.",
+      0
+    );
+    return false;
+  }
   funboxSaved = funbox;
   modeSaved = mode;
   active = funbox;
+  return true;
 }

--- a/src/js/test/funbox.js
+++ b/src/js/test/funbox.js
@@ -7,10 +7,10 @@ import Config, * as UpdateConfig from "./config";
 import * as Settings from "./settings";
 
 export let active = "none";
+export let funboxSaved = "none";
+export let modeSaved = null;
 let memoryTimer = null;
 let memoryInterval = null;
-let currentFunbox = "none";
-let currentMode = null;
 
 function showMemoryTimer() {
   $("#typingTest #memoryTimer").stop(true, true).animate(
@@ -74,8 +74,8 @@ export function toggleScript(...params) {
 
 export async function activate(funbox, mode) {
   if (funbox === undefined) {
-    funbox = currentFunbox;
-    mode = currentMode;
+    funbox = funboxSaved;
+    mode = modeSaved;
   }
   if (Misc.getCurrentLanguage().ligatures) {
     if (funbox == "choo_choo" || funbox == "earthquake") {
@@ -152,16 +152,17 @@ export async function activate(funbox, mode) {
     active = funbox;
   }
 
-  TestUI.updateModesNotice();
-  return true;
-}
-export function setFunbox(funbox, mode) {
-  currentFunbox = funbox;
-  currentMode = mode;
   if (funbox !== "layoutfluid" || mode !== "script") {
     if (Config.layout !== Config.savedLayout) {
       UpdateConfig.setLayout(Config.savedLayout);
       Settings.groups.layout.updateButton();
     }
   }
+  TestUI.updateModesNotice();
+  return true;
+}
+export function setFunbox(funbox, mode) {
+  funboxSaved = funbox;
+  modeSaved = mode;
+  active = funbox;
 }

--- a/src/js/test/test-logic.js
+++ b/src/js/test/test-logic.js
@@ -1658,8 +1658,8 @@ export function finish(difficultyFailed = false) {
   if (Config.blindMode) {
     testType += "<br>blind";
   }
-  if (Funbox.active !== "none") {
-    testType += "<br>" + Funbox.active.replace(/_/g, " ");
+  if (Funbox.funboxSaved !== "none") {
+    testType += "<br>" + Funbox.funboxSaved.replace(/_/g, " ");
   }
   if (Config.difficulty == "expert") {
     testType += "<br>expert";

--- a/src/js/test/test-logic.js
+++ b/src/js/test/test-logic.js
@@ -314,7 +314,6 @@ export function startTest() {
   LiveAcc.show();
   TimerProgress.update(TestTimer.time);
   TestTimer.clear();
-
   if (Funbox.active === "memory") {
     Funbox.resetMemoryTimer();
     $("#wordsWrapper").addClass("hidden");
@@ -575,6 +574,13 @@ export async function init() {
   //   $("#wordsWrapper").css("height", "auto");
   // } else {
   TestUI.showWords();
+  // if($(".page.active").attr("class") === $(".page.pageTest")){
+  //   Funbox.activate();
+  // }
+  if ($(".pageTest").hasClass("active")) {
+    Funbox.activate();
+  }
+
   // }
 }
 
@@ -621,6 +627,7 @@ export function restart(withSameWordset = false, nosave = false, event) {
     // incompleteTestSeconds += ;
     TestStats.incrementIncompleteSeconds(testSeconds - afkseconds);
     TestStats.incrementRestartCount();
+
     // restartCount++;
   }
 
@@ -697,6 +704,7 @@ export function restart(withSameWordset = false, nosave = false, event) {
         input.reset();
         PaceCaret.init();
         TestUI.showWords();
+        Funbox.activate();
       }
       if (Config.mode === "quote") {
         setRepeated(false);
@@ -924,6 +932,7 @@ export function finish(difficultyFailed = false) {
   LiveAcc.hide();
   TimerProgress.hide();
   Keymap.hide();
+  Funbox.activate("none", null);
   let stats = TestStats.calculateStats();
   if (stats === undefined) {
     stats = {

--- a/src/js/test/test-logic.js
+++ b/src/js/test/test-logic.js
@@ -314,6 +314,7 @@ export function startTest() {
   LiveAcc.show();
   TimerProgress.update(TestTimer.time);
   TestTimer.clear();
+
   if (Funbox.active === "memory") {
     Funbox.resetMemoryTimer();
     $("#wordsWrapper").addClass("hidden");
@@ -574,14 +575,10 @@ export async function init() {
   //   $("#wordsWrapper").css("height", "auto");
   // } else {
   TestUI.showWords();
-  // if($(".page.active").attr("class") === $(".page.pageTest")){
-  //   Funbox.activate();
   // }
   if ($(".pageTest").hasClass("active")) {
     Funbox.activate();
   }
-
-  // }
 }
 
 export function restart(withSameWordset = false, nosave = false, event) {
@@ -630,7 +627,6 @@ export function restart(withSameWordset = false, nosave = false, event) {
 
     // restartCount++;
   }
-
   if (Config.mode == "zen") {
     $("#words").empty();
   }

--- a/src/js/test/test-logic.js
+++ b/src/js/test/test-logic.js
@@ -624,9 +624,9 @@ export function restart(withSameWordset = false, nosave = false, event) {
     // incompleteTestSeconds += ;
     TestStats.incrementIncompleteSeconds(testSeconds - afkseconds);
     TestStats.incrementRestartCount();
-
     // restartCount++;
   }
+
   if (Config.mode == "zen") {
     $("#words").empty();
   }

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -137,7 +137,7 @@ export function changePage(page) {
     TestStats.resetIncomplete();
     ManualRestart.set();
     TestLogic.restart();
-    Funbox.activate();
+    Funbox.activate(Funbox.funboxSaved, Funbox.modeSaved);
   } else if (page == "about") {
     setPageTransition(true);
     TestLogic.restart();

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -14,6 +14,7 @@ import * as ManualRestart from "./manual-restart-tracker";
 import * as Settings from "./settings";
 import * as Account from "./account";
 import * as Leaderboards from "./leaderboards";
+import * as Funbox from "./funbox";
 
 export let pageTransition = false;
 
@@ -136,6 +137,7 @@ export function changePage(page) {
     TestStats.resetIncomplete();
     ManualRestart.set();
     TestLogic.restart();
+    Funbox.activate();
   } else if (page == "about") {
     setPageTransition(true);
     TestLogic.restart();
@@ -144,6 +146,7 @@ export function changePage(page) {
       history.pushState("about", null, "about");
       $(".page.pageAbout").addClass("active");
     });
+    Funbox.activate("none", null);
     TestConfig.hide();
     SignOutButton.hide();
   } else if (page == "settings") {
@@ -154,6 +157,7 @@ export function changePage(page) {
       history.pushState("settings", null, "settings");
       $(".page.pageSettings").addClass("active");
     });
+    Funbox.activate("none", null);
     Settings.update();
     TestConfig.hide();
     SignOutButton.hide();
@@ -176,6 +180,7 @@ export function changePage(page) {
           SignOutButton.show();
         }
       );
+      Funbox.activate("none", null);
       Account.update();
       TestConfig.hide();
     }
@@ -190,6 +195,7 @@ export function changePage(page) {
         history.pushState("login", null, "login");
         $(".page.pageLogin").addClass("active");
       });
+      Funbox.activate("none", null);
       TestConfig.hide();
       SignOutButton.hide();
     }


### PR DESCRIPTION
Changed how funbox was called to have whatever was selected be saved to a variable. For example, this makes it so when the "nausea" or "space balls" themes (or any future visual theme) are selected in settings they are "saved" but not "active". The settings page does not change and is still usable. This also makes it so that the funbox theme is temporarily disabled going into leaderboards, account, or about pages. Will temporarily disable when results screen is shown as well to address #937 