### PR TITLE
Update czech.json

### DIFF
--- a/static/languages/czech.json
+++ b/static/languages/czech.json
@@ -167,8 +167,6 @@
     "málo",
     "myslit",
     "stejně",
-    "-li",
-    "Český",
     "moc",
     "problém",
     "milión",


### PR DESCRIPTION
While browsing throuhg the czech language file I found 2 minor things:
- "-li" is not a word but rather a kind of suffix
- "Český" was mentioned twice + it shouldn't be capitalised because it's an adjective (unless it's the first word in a sentence)

It was kinda bugging me for a while so I decided to make a PR, hope it's fine :)
