### PR TITLE
Make default timer color "main" and full opacity

### DIFF
--- a/src/js/config.js
+++ b/src/js/config.js
@@ -77,11 +77,11 @@ let defaultConfig = {
   savedLayout: "default",
   confidenceMode: "off",
   indicateTypos: false,
-  timerStyle: "text",
+  timerStyle: "mini",
   colorfulMode: false,
   randomTheme: "off",
-  timerColor: "black",
-  timerOpacity: "0.25",
+  timerColor: "main",
+  timerOpacity: "1",
   stopOnError: "off",
   showAllLines: false,
   keymapMode: "off",
@@ -842,7 +842,7 @@ export function toggleHideExtraLetters() {
 
 export function setTimerStyle(style, nosave) {
   if (style == null || style == undefined) {
-    style = "bar";
+    style = "mini";
   }
   config.timerStyle = style;
   if (!nosave) saveToCookie();
@@ -1375,7 +1375,7 @@ export function setCustomBackground(value, nosave) {
 }
 
 export function setCustomBackgroundSize(value, nosave) {
-  if (value != "cover" && value != "contain" && value!= "max") {
+  if (value != "cover" && value != "contain" && value != "max") {
     value = "cover";
   }
   config.customBackgroundSize = value;

--- a/static/index.html
+++ b/static/index.html
@@ -1070,7 +1070,7 @@
               <div id="timerNumber" class="timerMain">
                 <div>60</div>
               </div>
-              <div id="miniTimerAndLiveWpm" class="timerMain">
+              <div id="miniTimerAndLiveWpm" class="timerMain size15">
                 <div class="time hidden">1:00</div>
                 <div class="wpm">60</div>
                 <div class="acc">100%</div>

--- a/static/index.html
+++ b/static/index.html
@@ -875,7 +875,7 @@
       </div>
     </div>
     <div id="timerWrapper">
-      <div id="timer"></div>
+      <div id="timer" class="timerMain"></div>
     </div>
     <div style="display: flex; justify-content: space-around">
       <div id="nitropay_ad_left" class="hidden"></div>
@@ -1067,10 +1067,10 @@
               <div id="caret" class="default size15"></div>
               <div id="paceCaret" class="default size15 hidden"></div>
               <input id="wordsInput" class="" tabindex="0" autocomplete="off" />
-              <div id="timerNumber">
+              <div id="timerNumber" class="timerMain">
                 <div>60</div>
               </div>
-              <div id="miniTimerAndLiveWpm">
+              <div id="miniTimerAndLiveWpm" class="timerMain">
                 <div class="time hidden">1:00</div>
                 <div class="wpm">60</div>
                 <div class="acc">100%</div>
@@ -1256,7 +1256,7 @@
                   </div>
                 </div>
               </div>
-              <div id="largeLiveWpmAndAcc">
+              <div id="largeLiveWpmAndAcc" class="timerMain">
                 <div id="liveWpm" class="hidden">123</div>
                 <div id="liveAcc" class="hidden">100%%</div>
               </div>


### PR DESCRIPTION
So it looks better by default with most theme. With some themes the default
black+0.25 was really hard to see, or just looked really bad.

An alternative way of doing this would be to make the timer color part of the theme, so each theme chooses what color it should use (and then some can keep the default black+0.25 if it looks better)

## serika dark (default)
![image](https://user-images.githubusercontent.com/21978144/113758017-56066600-96e1-11eb-8f61-96996021bc8c.png)
![image](https://user-images.githubusercontent.com/21978144/113766961-1133fc80-96ec-11eb-995a-6e260d837e10.png)

## terra
![image](https://user-images.githubusercontent.com/21978144/113758102-73d3cb00-96e1-11eb-9359-c2c0f03cdd44.png)
![image](https://user-images.githubusercontent.com/21978144/113766986-18f3a100-96ec-11eb-9040-09ef71cee915.png)

## matrix
![image](https://user-images.githubusercontent.com/21978144/113758129-7f26f680-96e1-11eb-92eb-2417c6623722.png)
![image](https://user-images.githubusercontent.com/21978144/113767005-21e47280-96ec-11eb-8701-01d05c84f0ba.png)

## 80s after dark
![image](https://user-images.githubusercontent.com/21978144/113758278-a8e01d80-96e1-11eb-887c-8bd87f0cd7c7.png)
![image](https://user-images.githubusercontent.com/21978144/113767028-2a3cad80-96ec-11eb-8376-409a11dc065c.png)

## arch
![image](https://user-images.githubusercontent.com/21978144/113758328-b72e3980-96e1-11eb-9c42-daba06d1e4b5.png)
![image](https://user-images.githubusercontent.com/21978144/113767055-30328e80-96ec-11eb-962b-054e787c2138.png)
