### PR TITLE
Added slovak_1k

### DIFF
--- a/static/languages/_list.json
+++ b/static/languages/_list.json
@@ -37,6 +37,7 @@
   ,"czech_1k"
   ,"czech_10k"
   ,"slovak"
+  ,"slovak_1k"
   ,"slovenian"
   ,"croatian"
   ,"dutch"


### PR DESCRIPTION
I have created a json file which contains 1000 most used slovak words. I have added "slovak_1k" language in _json file and also into _groups file. I hope it will be helpful. I have chosen the words according to this website: "https://invokeit.wordpress.com/frequency-word-lists/".
