### PR TITLE
Add .firebaserc_example back and update CONTRIBUTING.md so it doesn’t get deleted anymore

### DIFF
--- a/.firebaserc_example
+++ b/.firebaserc_example
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "your-firebase-project-id"
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@
 1. [Install the Firebase CLI](https://firebase.google.com/docs/cli)
 1. Run `firebase login` on your terminal to log in to the same google account as you just used to create the project.
 1. Git clone this project.
-1. Rename `.firebaserc_example` to `.firebaserc` and change the project name of default to the firebase project id you just created.
+1. Duplicate `.firebaserc_example`, rename the new file to `.firebaserc` and change the project name of default to the firebase project id you just created.
 
    - If `.firebaserc_example` does not exist after cloning, create your own with:
 
@@ -47,7 +47,6 @@
    - Create database
    - Start in test mode
    - Select default location and enable
-
 
 ## Building and Running
 


### PR DESCRIPTION
When I cloned the repository, the .firebaserc_example file was indeed not present. And I noticed that it is frequently deleted by mistake and re-added (see https://github.com/Miodec/monkeytype/pull/819). I believe this is due to the CONTRIBUTING.md instructions (cf https://github.com/Miodec/monkeytype/pull/384#issuecomment-702093486):

> Rename `.firebaserc_example` to `.firebaserc` 

Renaming the file itself will indeed delete it when committing, I updated the sentence so it doesn’t happen anymore.