### PR TITLE
Fixed undefined (NaN) issue with Personal Average Pace Caret when using quote mode

### DIFF
--- a/src/js/db.js
+++ b/src/js/db.js
@@ -212,23 +212,46 @@ export async function getUserAverageWpm10(
   function cont() {
     let wpmSum = 0;
     let count = 0;
+    let last10Wpm = 0;
+    let last10Count = 0;
     // You have to use every so you can break out of the loop
     dbSnapshot.results.every((result) => {
       if (
         result.mode == mode &&
-        result.mode2 == mode2 &&
         result.punctuation == punctuation &&
         result.language == language &&
         result.difficulty == difficulty
       ) {
-        wpmSum += result.wpm;
-        count++;
-        if (count >= 10) {
-          return false;
+        // Continue if the mode2 doesn't match unless it's a quote.
+        if (result.mode2 != mode2 && mode != "quote") {
+          return true;
+        }
+
+        // Grab the most recent 10 wpm's for the current mode.
+        if (last10Count < 10) {
+          last10Wpm += result.wpm;
+          last10Count++;
+        }
+
+        // Check mode2 matches and append, for quotes this is the quote id.
+        if (result.mode2 == mode2) {
+          wpmSum += result.wpm;
+          count++;
+          if (count >= 10) {
+            // Break out of every loop since we a maximum of the last 10 wpm results.
+            return false;
+          }
         }
       }
       return true;
     });
+
+    // Return the last 10 average wpm for quote if the current quote id has never been completed before by the user.
+    if (count == 0 && mode == "quote") {
+      return Math.round(last10Wpm / last10Count);
+    }
+
+    // Return the average wpm of the last 10 completions for the targeted test mode.
     return Math.round(wpmSum / count);
   }
 


### PR DESCRIPTION
Change pace caret for quotes to use average wpm of up to a max of the last 10 quotes completed in target mode if the current quote has never been completed before rather than returning (0 / 0) resulting in undefined (NaN), and displaying an invalid pace caret position in the block in certain situations.

This issue is not listed, but was discovered by me not long ago today.

Reproducing the issue:
1. Set the pace caret mode to "average" in settings.
2. Load up a test in quote mode (any sub-mode is fine).
3. Reload until you find a quote that you have completed before (displaying the average wpm of that quote).
3. Complete the test beating the pace caret so it doesn't disappear before navigating to the results.
4. Start another test, and if the new test quote is a quote you have not completed before, you will notice the pace caret position is in a bugged position in the block due to not being hidden from the previous test, and in the console you will see a log output of "avg pace NaN".