### PR TITLE
fix top filter does not show active settings between current and all

### DIFF
--- a/src/js/account/result-filters.js
+++ b/src/js/account/result-filters.js
@@ -60,6 +60,10 @@ let defaultResultFilters = {
   funbox: {
     none: true,
   },
+  filterSettings: {
+    all: true,
+    current: false,
+  },
 };
 
 export let filters;
@@ -144,7 +148,7 @@ export function updateActive() {
         aboveChartDisplay[group].all = false;
       }
       let buttonEl;
-      if (group === "date") {
+      if (group === "date" || group === "filterSettings") {
         buttonEl = $(
           `.pageAccount .group.topFilters .filterGroup[group="${group}"] .button[filter="${filter}"]`
         );
@@ -351,7 +355,7 @@ $(
 $(".pageAccount .topFilters .button.allFilters").click((e) => {
   Object.keys(getFilters()).forEach((group) => {
     Object.keys(getGroup(group)).forEach((filter) => {
-      if (group === "date") {
+      if (group === "date" || group === "filterSettings") {
         filters[group][filter] = false;
       } else {
         filters[group][filter] = true;
@@ -359,6 +363,7 @@ $(".pageAccount .topFilters .button.allFilters").click((e) => {
     });
   });
   filters["date"]["all"] = true;
+  filters["filterSettings"]["all"] = true;
   updateActive();
   save();
 });
@@ -412,6 +417,7 @@ $(".pageAccount .topFilters .button.currentConfigFilter").click((e) => {
   });
 
   filters["date"]["all"] = true;
+  filters["filterSettings"]["current"] = true;
   updateActive();
   save();
   console.log(getFilters());

--- a/static/index.html
+++ b/static/index.html
@@ -3593,12 +3593,14 @@
                 </div> -->
                 <div class="buttonsAndTitle" style="grid-column: 1/3">
                   <div class="title">filters</div>
-                  <div class="buttons">
-                    <div class="button allFilters">all</div>
-                    <div class="button currentConfigFilter">
+                  <div class="buttons filterGroup" group="filterSettings">
+                    <div class="button allFilters" filter="all">all</div>
+                    <div class="button currentConfigFilter" filter="current">
                       current settings
                     </div>
-                    <div class="button toggleAdvancedFilters">advanced</div>
+                    <div class="button toggleAdvancedFilters" filter="advanced">
+                      advanced
+                    </div>
                   </div>
                 </div>
                 <div


### PR DESCRIPTION
I noticed that in /account does not show what filter is active between "all" and "current settings"

Added a new group filter in account.js and index.html to track if the top filter "all" or "current settings" is active

Result
![](https://user-images.githubusercontent.com/38664193/115064849-6bd31280-9ebb-11eb-8813-89870e6afdf3.gif)

