### PR TITLE
Removed doubles and typos from German 1k

### DIFF
--- a/static/languages/german_1k.json
+++ b/static/languages/german_1k.json
@@ -178,7 +178,6 @@
     "machen",
     "lassen",
     "Als",
-    "Als",
     "Unternehmen",
     "andere",
     "ob",
@@ -783,7 +782,7 @@
     "DDR",
     "hohe",
     "Firmen",
-    "bzw",
+    "bzw.",
     "Koalition",
     "Mädchen",
     "Zur",
@@ -799,7 +798,7 @@
     "früheren",
     "dadurch",
     "ganzen",
-    "abend",
+    "abends",
     "erzählt",
     "Streit",
     "Vergangenheit",
@@ -882,7 +881,7 @@
     "heutigen",
     "Anteil",
     "Herr",
-    "Öffentlikeit",
+    "Öffentlichkeit",
     "Abend",
     "Selbst",
     "Liebe",
@@ -1001,7 +1000,6 @@
     "deutscher",
     "Worten",
     "Ihnen",
-    "zur Zeit",
     "voll"
   ]
 }


### PR DESCRIPTION
After further feedback and help removed two doubles and changed two typos. Also added a . in bzw to give it a bit more sence...
Btw, I am sorry I have to do this so often, but there were some mistakes and I'm an perfectionist...


