### PR TITLE
Ignoring Zen Trailing AFK #966

### DIFF
--- a/src/js/input-controller.js
+++ b/src/js/input-controller.js
@@ -232,7 +232,6 @@ function handleSpace(event, isEnter) {
     TestUI.updateActiveElement();
     Funbox.toggleScript(TestLogic.words.getCurrent());
     Caret.updatePosition();
-    TestStats.updateLastKeypress();
     TestStats.incrementKeypressCount();
     TestStats.pushKeypressWord(TestLogic.words.currentIndex);
     // currentKeypress.count++;
@@ -611,6 +610,7 @@ function handleAlpha(event) {
     }
   }
   TestStats.incrementKeypressCount();
+  TestStats.updateLastKeypress();
   TestStats.pushKeypressWord(TestLogic.words.currentIndex);
   // currentKeypress.count++;
   // currentKeypress.words.push(TestLogic.words.currentIndex);

--- a/src/js/input-controller.js
+++ b/src/js/input-controller.js
@@ -232,6 +232,7 @@ function handleSpace(event, isEnter) {
     TestUI.updateActiveElement();
     Funbox.toggleScript(TestLogic.words.getCurrent());
     Caret.updatePosition();
+    TestStats.updateLastKeypress();
     TestStats.incrementKeypressCount();
     TestStats.pushKeypressWord(TestLogic.words.currentIndex);
     // currentKeypress.count++;
@@ -288,6 +289,7 @@ function handleSpace(event, isEnter) {
     // currentKeypress.words.push(TestLogic.words.currentIndex);
     TestStats.incrementKeypressCount();
     TestStats.pushKeypressWord(TestLogic.words.currentIndex);
+    TestStats.updateLastKeypress();
     if (Config.difficulty == "expert" || Config.difficulty == "master") {
       TestLogic.fail();
       return;

--- a/src/js/input-controller.js
+++ b/src/js/input-controller.js
@@ -294,7 +294,6 @@ function handleSpace(event, isEnter) {
       return;
     } else if (TestLogic.words.currentIndex == TestLogic.words.length) {
       //submitted last word that is incorrect
-      TestStats.setLastSecondNotRound();
       TestLogic.finish();
       return;
     }
@@ -674,7 +673,6 @@ function handleAlpha(event) {
       TestLogic.input.pushHistory();
 
       TestLogic.corrected.pushHistory();
-      TestStats.setLastSecondNotRound();
       TestLogic.finish();
     }
   }

--- a/src/js/test/test-logic.js
+++ b/src/js/test/test-logic.js
@@ -949,8 +949,8 @@ export function finish(difficultyFailed = false) {
   Keymap.hide();
   Funbox.activate("none", null);
 
-  if (Config.mode == "zen") {
-    TestStats.removeZenAfkData();
+  if (Config.mode == "zen" || bailout) {
+    TestStats.removeAfkData();
   }
   let stats = TestStats.calculateStats();
   if (stats === undefined) {

--- a/src/js/test/test-logic.js
+++ b/src/js/test/test-logic.js
@@ -948,6 +948,10 @@ export function finish(difficultyFailed = false) {
   TimerProgress.hide();
   Keymap.hide();
   Funbox.activate("none", null);
+
+  if (Config.mode == "zen") {
+    TestStats.removeZenAfkData();
+  }
   let stats = TestStats.calculateStats();
   if (stats === undefined) {
     stats = {

--- a/src/js/test/test-logic.js
+++ b/src/js/test/test-logic.js
@@ -949,6 +949,10 @@ export function finish(difficultyFailed = false) {
   Keymap.hide();
   Funbox.activate("none", null);
 
+  if (Misc.roundTo2(TestStats.calculateTestSeconds()) % 1 != 0) {
+    TestStats.setLastSecondNotRound();
+  }
+
   if (Config.mode == "zen" || bailout) {
     TestStats.removeAfkData();
   }
@@ -1783,7 +1787,6 @@ export function fail() {
   input.pushHistory();
   corrected.pushHistory();
   TestStats.pushKeypressesToHistory();
-  TestStats.setLastSecondNotRound();
   finish(true);
   let testSeconds = TestStats.calculateTestSeconds(performance.now());
   let afkseconds = TestStats.calculateAfkSeconds();

--- a/src/js/test/test-stats.js
+++ b/src/js/test/test-stats.js
@@ -99,7 +99,7 @@ export function setInvalid() {
 
 export function calculateTestSeconds(now) {
   if (now === undefined) {
-    if (Config.mode == "zen") {
+    if (Config.mode == "zen" || TestLogic.bailout) {
       return (lastKeypress - start) / 1000;
     } else {
       return (end - start) / 1000;
@@ -226,12 +226,15 @@ export function pushMissedWord(word) {
   }
 }
 
-export function removeZenAfkData() {
+export function removeAfkData() {
   let testSeconds = calculateTestSeconds();
-  keypressPerSecond.splice(testSeconds);
-  keypressTimings.duration.array.splice(testSeconds);
-  keypressTimings.spacing.array.splice(testSeconds);
-  wpmHistory.splice(testSeconds);
+  let fullTestSeconds = (end - start) / 1000;
+  if (fullTestSeconds - testSeconds <= 7) {
+    keypressPerSecond.splice(testSeconds);
+    keypressTimings.duration.array.splice(testSeconds);
+    keypressTimings.spacing.array.splice(testSeconds);
+    wpmHistory.splice(testSeconds);
+  }
 }
 
 function countChars() {

--- a/src/js/test/test-stats.js
+++ b/src/js/test/test-stats.js
@@ -99,7 +99,8 @@ export function setInvalid() {
 
 export function calculateTestSeconds(now) {
   if (now === undefined) {
-    if (Config.mode == "zen" || TestLogic.bailout) {
+    let endAfkSeconds = (end - lastKeypress) / 1000;
+    if ((Config.mode == "zen" || TestLogic.bailout) && endAfkSeconds < 7) {
       return (lastKeypress - start) / 1000;
     } else {
       return (end - start) / 1000;
@@ -228,13 +229,10 @@ export function pushMissedWord(word) {
 
 export function removeAfkData() {
   let testSeconds = calculateTestSeconds();
-  let fullTestSeconds = (end - start) / 1000;
-  if (fullTestSeconds - testSeconds <= 7) {
-    keypressPerSecond.splice(testSeconds);
-    keypressTimings.duration.array.splice(testSeconds);
-    keypressTimings.spacing.array.splice(testSeconds);
-    wpmHistory.splice(testSeconds);
-  }
+  keypressPerSecond.splice(testSeconds);
+  keypressTimings.duration.array.splice(testSeconds);
+  keypressTimings.spacing.array.splice(testSeconds);
+  wpmHistory.splice(testSeconds);
 }
 
 function countChars() {

--- a/src/js/test/test-stats.js
+++ b/src/js/test/test-stats.js
@@ -17,6 +17,8 @@ export let currentKeypress = {
   words: [],
 };
 
+export let lastKeypress;
+
 // export let errorsPerSecond = [];
 // export let currentError = {
 //   count: 0,
@@ -97,7 +99,11 @@ export function setInvalid() {
 
 export function calculateTestSeconds(now) {
   if (now === undefined) {
-    return (end - start) / 1000;
+    if (Config.mode == "zen") {
+      return (lastKeypress - start) / 1000;
+    } else {
+      return (end - start) / 1000;
+    }
   } else {
     return (now - start) / 1000;
   }
@@ -109,6 +115,10 @@ export function setEnd(e) {
 
 export function setStart(s) {
   start = s;
+}
+
+export function updateLastKeypress() {
+  lastKeypress = performance.now();
 }
 
 export function pushToWpmHistory(word) {
@@ -214,6 +224,14 @@ export function pushMissedWord(word) {
   } else {
     missedWords[word]++;
   }
+}
+
+export function removeZenAfkData() {
+  let testSeconds = calculateTestSeconds();
+  keypressPerSecond.splice(testSeconds);
+  keypressTimings.duration.array.splice(testSeconds);
+  keypressTimings.spacing.array.splice(testSeconds);
+  wpmHistory.splice(testSeconds);
 }
 
 function countChars() {


### PR DESCRIPTION
This commit addresses the improvement suggested in #966. 

This code works by storing the last time an alpha key or the spacebar was pressed. I decided not to count pressing backspaces or caps locks as 'typing' but this can be changed by adding `TestStats.updateLastKeypress()` to the handling functions in `input-controller.js`. It uses this to create a new, shorter test time which is then used to cut the critical arrays which are used to calculate stats.
