### PR TITLE
fixed bug with plus one funbox

### DIFF
--- a/src/js/test/test-logic.js
+++ b/src/js/test/test-logic.js
@@ -410,7 +410,7 @@ export async function init() {
     if (Config.mode === "words" && Config.words === 0) {
       wordsBound = 100;
     }
-    if (Funbox.active === "plus_one") {
+    if (Funbox.funboxSaved === "plus_one") {
       wordsBound = 2;
     }
     let wordset = language.words;


### PR DESCRIPTION
Addressing #1309 

Test logic was calling the currently active funbox when checking for the "Plus one" funbox. Saved funbox will now be called to re-apply "plus one" when restarting test.