### PR TITLE
Fixed theme preview

### DIFF
--- a/src/js/commandline.js
+++ b/src/js/commandline.js
@@ -43,11 +43,11 @@ function showFound() {
     try {
       $.each(list.list, (index, obj) => {
         if (obj.found) {
+          obj.hover();
           if (!/theme/gi.test(obj.id) || obj.id === "toggleCustomTheme")
             ThemeController.clearPreview();
           if (!/font/gi.test(obj.id))
             Config.previewFontFamily(Config.fontFamily);
-          obj.hover();
           return false;
         }
       });
@@ -362,10 +362,10 @@ $("#commandLineWrapper #commandLine .suggestions").on("mouseover", (e) => {
     let list = CommandlineLists.current[CommandlineLists.current.length - 1];
     $.each(list.list, (index, obj) => {
       if (obj.id == hoverId) {
+        obj.hover();
         if (!/theme/gi.test(obj.id) || obj.id === "toggleCustomTheme")
           ThemeController.clearPreview();
         if (!/font/gi.test(obj.id)) Config.previewFontFamily(Config.fontFamily);
-        obj.hover();
       }
     });
   } catch (e) {}
@@ -483,11 +483,11 @@ $(document).keydown((e) => {
           CommandlineLists.current[CommandlineLists.current.length - 1];
         $.each(list.list, (index, obj) => {
           if (obj.id == hoverId) {
+            obj.hover();
             if (!/theme/gi.test(obj.id) || obj.id === "toggleCustomTheme")
               ThemeController.clearPreview();
             if (!/font/gi.test(obj.id))
               Config.previewFontFamily(Config.fontFamily);
-            obj.hover();
           }
         });
       } catch (e) {}

--- a/src/js/commandline.js
+++ b/src/js/commandline.js
@@ -43,11 +43,11 @@ function showFound() {
     try {
       $.each(list.list, (index, obj) => {
         if (obj.found) {
-          obj.hover();
           if (!/theme/gi.test(obj.id) || obj.id === "toggleCustomTheme")
             ThemeController.clearPreview();
           if (!/font/gi.test(obj.id))
-            Config.previewFontFamily(Config.fontFamily);
+            UpdateConfig.previewFontFamily(Config.fontFamily);
+          obj.hover();
           return false;
         }
       });
@@ -362,10 +362,11 @@ $("#commandLineWrapper #commandLine .suggestions").on("mouseover", (e) => {
     let list = CommandlineLists.current[CommandlineLists.current.length - 1];
     $.each(list.list, (index, obj) => {
       if (obj.id == hoverId) {
-        obj.hover();
         if (!/theme/gi.test(obj.id) || obj.id === "toggleCustomTheme")
           ThemeController.clearPreview();
-        if (!/font/gi.test(obj.id)) Config.previewFontFamily(Config.fontFamily);
+        if (!/font/gi.test(obj.id))
+          UpdateConfig.previewFontFamily(Config.fontFamily);
+        obj.hover();
       }
     });
   } catch (e) {}
@@ -483,11 +484,11 @@ $(document).keydown((e) => {
           CommandlineLists.current[CommandlineLists.current.length - 1];
         $.each(list.list, (index, obj) => {
           if (obj.id == hoverId) {
-            obj.hover();
             if (!/theme/gi.test(obj.id) || obj.id === "toggleCustomTheme")
               ThemeController.clearPreview();
             if (!/font/gi.test(obj.id))
-              Config.previewFontFamily(Config.fontFamily);
+              UpdateConfig.previewFontFamily(Config.fontFamily);
+            obj.hover();
           }
         });
       } catch (e) {}


### PR DESCRIPTION
Possible fix to get theme preview to work? Looks like hover function for items in theme list is not being called for some reason. Moving the call up a few lines of code seems to fix the issue. Maybe clearPreview function is doing something? I am still quite new to javascript so maybe I am missing something idk.


Addresses #1307 