### PR TITLE
Add missing "on" word to blind mode setting

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -2051,7 +2051,7 @@
                     off
                   </div>
                   <div class="button on" tabindex="0" onclick="this.blur();">
-                    ⠀
+                    on
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Simply added the missing word "on" to the index.html for the "blind mode" setting:

![image](https://user-images.githubusercontent.com/67607370/117465795-ab6ba800-af17-11eb-8e55-5a0e5f8ec6cc.png)