### PR TITLE
Encode tests in URL.

### DIFF
--- a/src/js/popups/custom-text-popup.js
+++ b/src/js/popups/custom-text-popup.js
@@ -7,6 +7,7 @@ import * as WordFilterPopup from "./word-filter-popup";
 
 let wrapper = "#customTextPopupWrapper";
 let popup = "#customTextPopup";
+let maxUrlEncodeLength = 10000;
 
 export function show() {
   if ($(wrapper).hasClass("hidden")) {
@@ -84,6 +85,7 @@ $(`${popup} .randomInputFields .time input`).keypress((e) => {
 
 $("#customTextPopup .apply").click(() => {
   let text = $("#customTextPopup textarea").val();
+
   text = text.trim();
   // text = text.replace(/[\r]/gm, " ");
   text = text.replace(/\\\\t/gm, "\t");
@@ -100,6 +102,17 @@ $("#customTextPopup .apply").click(() => {
   }
   // text = Misc.remove_non_ascii(text);
   text = text.replace(/[\u2060]/g, "");
+
+  let url = new URL(window.location.href);
+  url.searchParams.set(
+    "custom",
+    text.length <= maxUrlEncodeLength
+      ? text.replaceAll(" ", CustomText.urlWordSeparator)
+      : ""
+  );
+  url.search = decodeURI(url.search);
+  window.history.replaceState(null, null, url);
+
   text = text.split(" ");
   CustomText.setText(text);
   CustomText.setWord(parseInt($("#customTextPopup .wordcount input").val()));

--- a/src/js/test/custom-text.js
+++ b/src/js/test/custom-text.js
@@ -1,4 +1,10 @@
-export let text = "The quick brown fox jumps over the lazy dog".split(" ");
+let wordParams = new URL(window.location.href).searchParams.get("custom");
+let defaultText = "The quick brown fox jumps over the lazy dog";
+
+export let urlWordSeparator = "|";
+export let text = wordParams
+  ? wordParams.split(urlWordSeparator)
+  : defaultText.split(" ");
 export let isWordRandom = false;
 export let isTimeRandom = false;
 export let word = "";


### PR DESCRIPTION
Custom tests are now encoded in the URL when applied for easier sharing:
http://monkeytype.com/?custom=Lorem|ipsum|dolor|sit|ameta
The maxUrlEncodeLength prevents the creation of URLs rejected by the browser or server.

This is a feature I'm personally quite fond of with other typing sites, but I get that you might not want go this route. If so, I hope you'll consider allowing users to create their own custom challenges instead.