### PR TITLE
Wrong name in slovak_10k.json file

### DIFF
--- a/static/languages/slovak_10k.json
+++ b/static/languages/slovak_10k.json
@@ -1,5 +1,5 @@
 {
-  "name": "slovak_1k",
+  "name": "slovak_10k",
   "leftToRight": true,
   "words": [
     "to",


### PR DESCRIPTION
Fixing a problem: wrong name in slovak_10k.json file. It was my mistake when I was creating the file. I have forgotten to change the name in slovak_10k.json file.

I hope it will work just fine now.


Maclogger
