### PR TITLE
Add handsdown reference layout

### DIFF
--- a/src/js/layouts.js
+++ b/src/js/layouts.js
@@ -235,6 +235,16 @@ const layouts = {
             " "
         ]
     },
+    handsdown: {
+        keymapShowTopRow: false,
+        keys: [
+            "`~", "1!", "2@", "3#", "4$", "5%", "6^", "7&", "8*", "9(", "0)", "-_", "=+",
+            "qQ", "cC", "hH", "pP", "vV", "kK", "yY", "oO", "jJ", "/?", "[{", "]}", "\\|",
+            "rR", "sS", "nN", "tT", "gG", "wW", "uU", "eE", "iI", "aA", ";:",
+            "\\|", "xX", "mM", "lL", "dD", "bB", "zZ", "fF", "'\"", ",<", ".>",
+            " "
+        ]
+    },
     handsdown_alt: {
         keymapShowTopRow: false,
         keys: [


### PR DESCRIPTION
This is the reference version of the Hands Down layout as found here: http://handsdownlayout.com

For easier reference, the core is:

```
q c h p v   k y o j / 
r s n t g   w u e i a
x m l d b   z f ' , .
```

