### PR TITLE
fixed keymap not highlighting in simon says

### DIFF
--- a/src/js/test/funbox.js
+++ b/src/js/test/funbox.js
@@ -137,6 +137,7 @@ export async function activate(funbox, mode) {
       );
       UpdateConfig.setKeymapMode("next");
       Settings.groups.keymapMode.updateButton();
+      TestUI.showWords();
       TestLogic.restart();
     }
 


### PR DESCRIPTION
Fixes #1435 

As mentioned in the issue...

$(".active-key").removeClass("active-key"); in config.js is being called after active key is set in keymap.js so when the test starts there is no key highlighted.

After looking in the call stacks for these functions I am still unsure why this is happening but manually calling       TestUI.showWords(); in funbox.js to call the highlighting function seems to fix everything as we are essentially calling the highlighting function in keymap.js AFTER its been set via funbox.js