### PR TITLE
fix GitHub spelling on about page

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1682,7 +1682,7 @@
                   target="_blank"
                 >
                   <div class="fab fa-github"></div>
-                  Github
+                  GitHub
                 </a>
               </div>
             </div>


### PR DESCRIPTION
Signed-off-by: Oxygemo <alej0hio2007@gmail.com>

<!-- please read the comments -->

<!-- Adding a language or a theme? For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well. For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps! 

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot. 

 -->

### Description
On the About page, GitHub is displayed as Github. This is a common spelling mistake, so I fixed it.



<!-- please check the items you have completed -->
### Checklist 
- [x] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/Miodec/monkeytype/blob/master/CODE_OF_CONDUCT.md) and the [`CONTRIBUTING.md`](https://github.com/Miodec/monkeytype/blob/master/CONTRIBUTING.md)
- [x] I checked if my PR has any bugs or other issues that could reduce the stability of the project
- [x] I understand that the maintainer has the right to reject my contribution and it may not get accepted.



<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

Resolves #


<!-- pro tip: you can check checkboxes by putting an x inside the brackets   [x] -->
