### PR TITLE
 Add VSCode Theme (Dark)

### DIFF
--- a/static/themes/_list.json
+++ b/static/themes/_list.json
@@ -567,6 +567,6 @@
   {
     "name": "vscode",
     "bgColor": "#1E1E1E",
-    "textColor": "#D4D4D4"
+    "textColor": "#007acc"
   }
 ]

--- a/static/themes/_list.json
+++ b/static/themes/_list.json
@@ -563,5 +563,10 @@
     "name": "ez_mode",
     "bgColor": "#0171cd",
     "textColor": "#fa62d5"
+  },
+  {
+    "name": "vscode",
+    "bgColor": "#1E1E1E",
+    "textColor": "#D4D4D4"
   }
 ]

--- a/static/themes/vscode.css
+++ b/static/themes/vscode.css
@@ -2,8 +2,8 @@
   --bg-color: #1e1e1e;
   --main-color: #007acc;
   --caret-color: #569cd6;
-  --sub-color: #a6a6a6;
-  --text-color: #007acc;
+  --sub-color: #707070;
+  --text-color: #d4d4d4;
   --error-color: #f44747;
   --error-extra-color: #f44747;
   --colorful-error-color: #f44747;

--- a/static/themes/vscode.css
+++ b/static/themes/vscode.css
@@ -1,0 +1,11 @@
+:root {
+  --bg-color: #1e1e1e;
+  --main-color: #007acc;
+  --caret-color: #569cd6;
+  --sub-color: #a6a6a6;
+  --text-color: #007acc;
+  --error-color: #f44747;
+  --error-extra-color: #f44747;
+  --colorful-error-color: #f44747;
+  --colorful-error-extra-color: #f44747;
+}

--- a/static/themes/vscode.css
+++ b/static/themes/vscode.css
@@ -2,7 +2,7 @@
   --bg-color: #1e1e1e;
   --main-color: #007acc;
   --caret-color: #569cd6;
-  --sub-color: #707070;
+  --sub-color: #4d4d4d;
   --text-color: #d4d4d4;
   --error-color: #f44747;
   --error-extra-color: #f44747;


### PR DESCRIPTION
<!-- please read the comments -->

<!-- Adding a language or a theme? For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well. For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps! 

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot. 

 -->

![image](https://user-images.githubusercontent.com/57069715/124395679-b3707a00-dd05-11eb-8a6c-e79bc53c279b.png)


### Description
I have added a new theme to Monkeytype, based on VSCode's default dark theme. 

The values are taken from [here](https://github.com/microsoft/vscode/blob/main/extensions/theme-defaults/themes/dark_vs.json)

<!-- please check the items you have completed -->
### Checklist 
- [x] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/Miodec/monkeytype/blob/master/CODE_OF_CONDUCT.md) and the [`CONTRIBUTING.md`](https://github.com/Miodec/monkeytype/blob/master/CONTRIBUTING.md)
- [x] I checked if my PR has any bugs or other issues that could reduce the stability of the project
- [x] I understand that the maintainer has the right to reject my contribution and it may not get accepted.
- [x] If my PR is a new language or theme I modified the appropriate files to incorporate the language or theme   <!-- Delete if that is not the case-->

<!-- pro tip: you can check checkboxes by putting an x inside the brackets   [x] -->
