### PR TITLE
Fix stop on word replay error

### DIFF
--- a/src/js/input-controller.js
+++ b/src/js/input-controller.js
@@ -320,6 +320,7 @@ function handleSpace(event, isEnter) {
       }
       if (Config.stopOnError == "word") {
         TestLogic.input.appendCurrent(" ");
+        Replay.addReplayEvent("incorrectLetter", "_");
         TestUI.updateWordElement(true);
         Caret.updatePosition();
       }


### PR DESCRIPTION
<!-- please read the comments -->

<!-- Adding a language or a theme? For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well. For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps! 

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot. 

 -->

### Description
<!-- Please describe the change(s) made in your PR -->
Added a line to input-controller.js that adds an incorrectLetter event to the replay if stop on word is active and the user attempted to submit an incorrect word.


<!-- please check the items you have completed -->
### Checklist 
- [x] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/Miodec/monkeytype/blob/master/CODE_OF_CONDUCT.md) and the [`CONTRIBUTING.md`](https://github.com/Miodec/monkeytype/blob/master/CONTRIBUTING.md)
- [x] I checked if my PR has any bugs or other issues that could reduce the stability of the project
- [x] I understand that the maintainer has the right to reject my contribution and it may not get accepted.
- [x] If my PR is a new language or theme I modified the appropriate files to incorporate the language or theme   <!-- Delete if that is not the case-->



<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->


<!-- pro tip: you can check checkboxes by putting an x inside the brackets   [x] -->
