### PR TITLE
Add media-query for cleaner #customTextPopup for under 1050px and 600px screens

### DIFF
--- a/src/sass/media-queries.scss
+++ b/src/sass/media-queries.scss
@@ -20,6 +20,13 @@
       }
     }
   }
+  #customTextPopup {
+    width: 80vw !important;
+
+    .wordfilter.button {
+      width: 50% !important;
+    }
+  }
 }
 
 @media only screen and (max-width: 800px) {
@@ -156,6 +163,20 @@
   #commandLine,
   #commandLineInput {
     width: 500px !important;
+  }
+  #customTextPopupWrapper {
+    #customTextPopup {
+      .wordfilter.button {
+        width: 100% !important;
+        justify-self: auto;
+      }
+
+      .inputs {
+        display: flex !important;
+        flex-direction: column;
+        justify-content: flex-start;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### Description
<!-- Please describe the change(s) made in your PR -->
Added a few lines of scss so that the popup for changing the custom text looks cleaner on smaller screens. The left image is the current UI and the right is after the edit. 
<div style="display: flex; align-items: center;">
<img width='48%' src="https://user-images.githubusercontent.com/44737273/124413158-0d675300-dd8b-11eb-86ab-8eb0a8f1e0f4.png">
<img width='48%' src="https://user-images.githubusercontent.com/44737273/124413172-135d3400-dd8b-11eb-92cb-fd2e9d1981be.png">
</div>

I know this is not really important (like, who uses monkeytype on mobile?), but I thought it would be a nice addition, especially since all the other parts of the UI are so nice and clean. Also, I'm thinking of adding more media queries for some other parts (login and leaderboard screens) as well. I'm hoping to get a lay of the land for the codebase before moving on to larger PRs and bug fixes. Thank you!

<!-- please check the items you have completed -->
### Checklist 
- [x] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/Miodec/monkeytype/blob/master/CODE_OF_CONDUCT.md) and the [`CONTRIBUTING.md`](https://github.com/Miodec/monkeytype/blob/master/CONTRIBUTING.md)
- [x] I checked if my PR has any bugs or other issues that could reduce the stability of the project
- [x] I understand that the maintainer has the right to reject my contribution, and it may not get accepted.