### PR TITLE
Add weakspot mode.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -168,6 +168,7 @@ const refactoredSrc = [
   "./src/js/test/layout-emulator.js",
   "./src/js/test/poetry.js",
   "./src/js/test/today-tracker.js",
+  "./src/js/test/weak-spot.js",
   "./src/js/replay.js",
 ];
 

--- a/src/js/input-controller.js
+++ b/src/js/input-controller.js
@@ -23,6 +23,7 @@ import * as Focus from "./focus";
 import * as ShiftTracker from "./shift-tracker";
 import * as Replay from "./replay.js";
 import * as MonkeyPower from "./monkey-power";
+import * as WeakSpot from "./weak-spot";
 
 $("#wordsInput").keypress((event) => {
   event.preventDefault();
@@ -660,7 +661,7 @@ function handleAlpha(event) {
       );
     }
   }
-  TestStats.updateWeaknessScore(nextCharInWord, thisCharCorrect);
+  WeakSpot.updateScore(nextCharInWord, thisCharCorrect);
 
   if (thisCharCorrect) {
     Sound.playClick(Config.playSoundOnClick);

--- a/src/js/input-controller.js
+++ b/src/js/input-controller.js
@@ -660,6 +660,7 @@ function handleAlpha(event) {
       );
     }
   }
+  TestStats.updateWeaknessScore(nextCharInWord, thisCharCorrect);
 
   if (thisCharCorrect) {
     Sound.playClick(Config.playSoundOnClick);

--- a/src/js/test/test-logic.js
+++ b/src/js/test/test-logic.js
@@ -32,6 +32,7 @@ import * as Replay from "./replay.js";
 import * as MonkeyPower from "./monkey-power";
 import * as Poetry from "./poetry.js";
 import * as TodayTracker from "./today-tracker";
+import * as WeakSpot from "./weak-spot";
 
 let glarsesMode = false;
 
@@ -574,15 +575,7 @@ export async function init() {
           UpdateConfig.setNumbers(false, true);
           randomWord = Misc.getASCII();
         } else if (Config.funbox === "weakspot") {
-          let highScore = TestStats.weaknessScore(randomWord);
-          for (let i = 0; i < 20; i++) {
-            let newWord = wordset[Math.floor(Math.random() * wordset.length)];
-            let newScore = TestStats.weaknessScore(newWord);
-            if (newScore > highScore) {
-              randomWord = newWord;
-              highScore = newScore;
-            }
-          }
+          randomWord = WeakSpot.getWord(wordset);
         }
 
         if (Config.punctuation) {

--- a/src/js/test/test-logic.js
+++ b/src/js/test/test-logic.js
@@ -573,6 +573,16 @@ export async function init() {
           UpdateConfig.setPunctuation(false, true);
           UpdateConfig.setNumbers(false, true);
           randomWord = Misc.getASCII();
+        } else if (Config.funbox === "weakspot") {
+          let highScore = TestStats.weaknessScore(randomWord);
+          for (let i = 0; i < 20; i++) {
+            let newWord = wordset[Math.floor(Math.random() * wordset.length)];
+            let newScore = TestStats.weaknessScore(newWord);
+            if (newScore > highScore) {
+              randomWord = newWord;
+              highScore = newScore;
+            }
+          }
         }
 
         if (Config.punctuation) {

--- a/src/js/test/test-stats.js
+++ b/src/js/test/test-stats.js
@@ -42,8 +42,6 @@ export let keypressTimings = {
   },
 };
 
-export let weaknessScores = {};
-
 export function restart() {
   start = 0;
   end = 0;
@@ -80,7 +78,6 @@ export function restart() {
       array: [],
     },
   };
-  // Don't reset weaknessScores, they should be kept across tests.
 }
 
 export let restartCount = 0;
@@ -221,37 +218,6 @@ export function incrementAccuracy(correctincorrect) {
   } else {
     accuracy.incorrect++;
   }
-}
-
-// Parameters for per-char weakness scores.
-const adjustRate = 0.02;
-// TODO: base these on WPM or something instead of constants
-const defaultScore = 500;
-const incorrectPenalty = 5000;
-
-export function updateWeaknessScore(char, isCorrect) {
-  let score = 0.0;
-  if (keypressTimings.spacing.array.length > 0) {
-    score +=
-      keypressTimings.spacing.array[keypressTimings.spacing.array.length - 1];
-  }
-  if (!isCorrect) {
-    score += incorrectPenalty;
-  }
-  if (!(char in weaknessScores)) {
-    weaknessScores[char] = defaultScore;
-  }
-  // Keep an exponential moving average of the score over time.
-  weaknessScores[char] =
-    score * adjustRate + weaknessScores[char] * (1 - adjustRate);
-}
-
-export function weaknessScore(word) {
-  let total = 0.0;
-  for (const c of word) {
-    total += c in weaknessScores ? weaknessScores[c] : defaultScore;
-  }
-  return total / word.length;
 }
 
 export function setKeypressTimingsTooLong() {

--- a/src/js/test/test-stats.js
+++ b/src/js/test/test-stats.js
@@ -42,6 +42,8 @@ export let keypressTimings = {
   },
 };
 
+export let weaknessScores = {};
+
 export function restart() {
   start = 0;
   end = 0;
@@ -218,6 +220,37 @@ export function incrementAccuracy(correctincorrect) {
   } else {
     accuracy.incorrect++;
   }
+}
+
+// Parameters for per-char weakness scores.
+const adjustRate = 0.02;
+// TODO: base these on WPM or something instead of constants
+const defaultScore = 500;
+const incorrectPenalty = 5000;
+
+export function updateWeaknessScore(char, isCorrect) {
+  let score = 0.0;
+  if (keypressTimings.spacing.array.length > 0) {
+    score +=
+      keypressTimings.spacing.array[keypressTimings.spacing.array.length - 1];
+  }
+  if (!isCorrect) {
+    score += incorrectPenalty;
+  }
+  if (!(char in weaknessScores)) {
+    weaknessScores[char] = defaultScore;
+  }
+  // Keep an exponential moving average of the score over time.
+  weaknessScores[char] =
+    score * adjustRate + weaknessScores[char] * (1 - adjustRate);
+}
+
+export function weaknessScore(word) {
+  let total = 0.0;
+  for (const c of word) {
+    total += c in weaknessScores ? weaknessScores[c] : defaultScore;
+  }
+  return total / word.length;
 }
 
 export function setKeypressTimingsTooLong() {

--- a/src/js/test/test-stats.js
+++ b/src/js/test/test-stats.js
@@ -80,6 +80,7 @@ export function restart() {
       array: [],
     },
   };
+  // Don't reset weaknessScores, they should be kept across tests.
 }
 
 export let restartCount = 0;

--- a/src/js/test/weak-spot.js
+++ b/src/js/test/weak-spot.js
@@ -1,0 +1,49 @@
+import * as TestStats from "./test-stats";
+
+const adjustRate = 0.02;
+const wordSamples = 20;
+
+// TODO: base these on WPM or something instead of constants
+const defaultScore = 500;
+const incorrectPenalty = 5000;
+
+let scores = {};
+
+export function updateScore(char, isCorrect) {
+  let score = 0.0;
+  const timings = TestStats.keypressTimings.spacing.array;
+  if (timings.length > 0) {
+    score += timings[timings.length - 1];
+  }
+  if (!isCorrect) {
+    score += incorrectPenalty;
+  }
+  if (!(char in scores)) {
+    scores[char] = defaultScore;
+  }
+  // Keep an exponential moving average of the score over time.
+  scores[char] =
+    score * adjustRate + scores[char] * (1 - adjustRate);
+}
+
+export function getWord(wordset) {
+  let highScore;
+  let randomWord;
+  for (let i = 0; i < wordSamples; i++) {
+    let newWord = wordset[Math.floor(Math.random() * wordset.length)];
+    let newScore = score(newWord);
+    if (i == 0 || newScore > highScore) {
+      randomWord = newWord;
+      highScore = newScore;
+    }
+  }
+  return randomWord;
+}
+
+function score(word) {
+  let total = 0.0;
+  for (const c of word) {
+    total += c in scores ? scores[c] : defaultScore;
+  }
+  return total / word.length;
+}

--- a/src/js/test/weak-spot.js
+++ b/src/js/test/weak-spot.js
@@ -22,8 +22,7 @@ export function updateScore(char, isCorrect) {
     scores[char] = defaultScore;
   }
   // Keep an exponential moving average of the score over time.
-  scores[char] =
-    score * adjustRate + scores[char] * (1 - adjustRate);
+  scores[char] = score * adjustRate + scores[char] * (1 - adjustRate);
 }
 
 export function getWord(wordset) {

--- a/static/funbox/_list.json
+++ b/static/funbox/_list.json
@@ -108,6 +108,11 @@
     "name": "poetry",
     "type": "script",
     "info": "Practice typing some beautiful prose."
+  },
+  {
+    "name": "weakspot",
+    "type": "script",
+    "info": "Focus on slow and mistyped letters."
   }
 ]
 


### PR DESCRIPTION
### Description
Keeps track of a per-character "weakness" score, basically a moving average of the spacing duration with a penalty for incorrect letters. The weakspot funbox mode uses this to bias towards words with lots of weak letters.

There are a few hardcoded parameters here that I tweaked a bit until it seemed right to me, but could use some work. LMK if there's a better place to put them.

I've only tested it with English; it should work with other scripts but might behave a little weirdly if there are a lot more characters. (It wouldn't break, it just might not make obviously sensible word choices.)

It doesn't persist weakness scores at the moment. Having used it for a bit I actually like it that way, it gives a feel of working on particular things for one session but being able to reset it.

### Checklist 
- [x] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/Miodec/monkeytype/blob/master/CODE_OF_CONDUCT.md) and the [`CONTRIBUTING.md`](https://github.com/Miodec/monkeytype/blob/master/CONTRIBUTING.md)
- [x] I checked if my PR has any bugs or other issues that could reduce the stability of the project
- [x] I understand that the maintainer has the right to reject my contribution and it may not get accepted.

