### PR TITLE
Add APT layout

### DIFF
--- a/src/js/layouts.js
+++ b/src/js/layouts.js
@@ -365,5 +365,15 @@ const layouts = {
             " "
         ],
     },
+    APT: {
+        keymapShowTopRow: false,
+        keys: [
+            "`~", "1!", "2@", "3#", "4$", "5%", "6^", "7&", "8*", "9(", "0)", "-_", "=+",
+            "wW", "cC", "dD", "lL", "'\"", "/?", "yY", "oO", "uU", "qQ", "[{", "]}", "\\|",
+            "rR", "sS", "tT", "hH", "kK", "pP", "nN", "eE", "iI", "aA", ";:",
+            "\\|", "vV", "bB", "gG", "mM", ",<", ".>", "fF", "jJ", "xX", "zZ",
+            " "
+        ]
+    },
 }
 export default layouts;


### PR DESCRIPTION
### Description
<!-- Please describe the change(s) made in your PR -->
I've added a few other people's layouts recently, and now I'm asking to add my own I use every day.

https://github.com/Apsu/APT repo with details is here

APT is competitive with other top tier optimized layouts on various analyzers, and the symmetric version is the only other center punctuation layout besides Engram, so I think it's worth a spot here.

<!-- please check the items you have completed -->
### Checklist 
- [x] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/Miodec/monkeytype/blob/master/CODE_OF_CONDUCT.md) and the [`CONTRIBUTING.md`](https://github.com/Miodec/monkeytype/blob/master/CONTRIBUTING.md)
- [x] I checked if my PR has any bugs or other issues that could reduce the stability of the project
- [x] I understand that the maintainer has the right to reject my contribution and it may not get accepted.