### PR TITLE
Fixed Bug: 'custom' used to appear two times under highest wpm value …

### DIFF
--- a/src/js/account.js
+++ b/src/js/account.js
@@ -657,7 +657,10 @@ export function update() {
           ? ",<br> " + (result.punctuation ? "&" : "") + "with numbers"
           : "";
         topWpm = result.wpm;
-        topMode = result.mode + " " + result.mode2 + puncsctring + numbsctring;
+        if (result.mode == "custom") topMode = result.mode;
+        else
+          topMode =
+            result.mode + " " + result.mode2 + puncsctring + numbsctring;
       }
 
       totalWpm += result.wpm;


### PR DESCRIPTION
### Description
<!-- Please describe the change(s) made in your PR -->



<!-- please check the items you have completed -->
### Checklist 
- [x] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/Miodec/monkeytype/blob/master/CODE_OF_CONDUCT.md) and the [`CONTRIBUTING.md`](https://github.com/Miodec/monkeytype/blob/master/CONTRIBUTING.md)
- [x] I checked if my PR has any bugs or other issues that could reduce the stability of the project
- [x] I understand that the maintainer has the right to reject my contribution and it may not get accepted.


<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
Resolves #
As someone mentioned in the Discord, when in custom mode, the mode name would appear 2 times under 'highest wpm'

