### PR TITLE
Add GitHub workflow to lint and auto-format PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: Lint and auto-format PRs
+
+permissions:
+  contents: write
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  lint_and_format:
+    name: Lint and auto-format
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout previous commit and then pull, to fetch everything in between
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.base.sha}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+      - run: |
+          git pull origin ${{github.event.pull_request.head.ref}}
+          git checkout ${{github.event.pull_request.head.ref}}
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.3.0
+        with:
+         node-version: 14
+         cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npx gulp lint
+
+      - name: Run Prettier
+        run: npx pretty-quick --branch ${{github.event.pull_request.base.sha}}
+
+      - name: Commit and push
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          git add --update
+          git commit -m "Auto-format with Prettier" || :
+          git push origin HEAD:${{github.event.pull_request.head.ref}}


### PR DESCRIPTION
<!-- please read the comments -->

<!-- Adding a language or a theme? For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well. For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps! 

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot. 

 -->

### Description
Adds a workflow that on every PR **merge** to **any** branch, runs prettier (`pretty-quick`) to fix the new commits. This should finally fix the issues with formatting coming from PRs made through the GitHub UI or other means that skip the pre-commit hook.

After merging, you should run
```
npx prettier --write .
```
on all active branches to fix all leftover formatting issues.
After this, no more badly formatted code should ever reach master again, which means no more noise diff on unrelated commits :)

<!-- please check the items you have completed -->
### Checklist 
- [X] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/Miodec/monkeytype/blob/master/CODE_OF_CONDUCT.md) and the [`CONTRIBUTING.md`](https://github.com/Miodec/monkeytype/blob/master/CONTRIBUTING.md)
- [X] I checked if my PR has any bugs or other issues that could reduce the stability of the project
- [X] I understand that the maintainer has the right to reject my contribution and it may not get accepted.

Marking as draft until input rewrite is merged so I don't have to fix new formatting conflicts >:)