### PR TITLE
Simplify replay seek click handler

### DIFF
--- a/src/js/replay.js
+++ b/src/js/replay.js
@@ -264,27 +264,15 @@ $(".pageTest #playpauseReplayButton").click(async (event) => {
   }
 });
 
-$("#replayWords").click((event) => {
+$("#replayWords").on("click", "letter", (event) => {
   //allows user to click on the place they want to start their replay at
   pauseReplay();
   const replayWords = document.querySelector("#replayWords");
-  let range;
-  let textNode;
-
-  if (document.caretPositionFromPoint) {
-    // standard
-    range = document.caretPositionFromPoint(event.pageX, event.pageY);
-    textNode = range.offsetNode;
-  } else if (document.caretRangeFromPoint) {
-    // WebKit
-    range = document.caretRangeFromPoint(event.pageX, event.pageY);
-    textNode = range.startContainer;
-  }
 
   const words = [...replayWords.children];
-  targetWordPos = words.indexOf(textNode.parentNode.parentNode);
+  targetWordPos = words.indexOf(event.target.parentNode);
   const letters = [...words[targetWordPos].children];
-  targetCurPos = letters.indexOf(textNode.parentNode);
+  targetCurPos = letters.indexOf(event.target);
 
   initializeReplayPrompt();
   loadOldReplay();


### PR DESCRIPTION
### Description
Makes use of jQuery.fn.on 2nd argument selector
(https://stackoverflow.com/a/1207393/6791873).

Apart from being a lot simpler and cross-platform, this also fixes replay
seeking breaking in some strange conditions like having the Firefox
devtools open. Yes, it took me a while to figure that one out.

This, combined with the input rewrite #1325, should fix all replay problems/errors I personally came across.

### Checklist 
- [X] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/Miodec/monkeytype/blob/master/CODE_OF_CONDUCT.md) and the [`CONTRIBUTING.md`](https://github.com/Miodec/monkeytype/blob/master/CONTRIBUTING.md)
- [X] I checked if my PR has any bugs or other issues that could reduce the stability of the project
- [X] I understand that the maintainer has the right to reject my contribution and it may not get accepted.