### PR TITLE
Improvements to weakspot.

### DIFF
--- a/src/js/test/test-logic.js
+++ b/src/js/test/test-logic.js
@@ -550,6 +550,7 @@ export async function init() {
           randomWord = wordset[Math.floor(Math.random() * wordset.length)];
         }
 
+        console.log(Config.funbox);
         if (Config.funbox === "rAnDoMcAsE") {
           let randomcaseword = "";
           for (let i = 0; i < randomWord.length; i++) {

--- a/src/js/test/weak-spot.js
+++ b/src/js/test/weak-spot.js
@@ -7,7 +7,7 @@ const adjustRate = 0.02;
 
 // Choose the highest scoring word from this many random words. Higher values
 // will choose words with more weak letters on average.
-const wordSamples = 20;
+const wordSamples = 500;
 
 // The score that every character starts on. The ideal value would be the
 // average spacing in milliseconds, but since we don't know that at the start,
@@ -17,7 +17,12 @@ const defaultScore = 500;
 // Score penatly (in milliseconds) for getting a letter wrong.
 const incorrectPenalty = 5000;
 
+const pairWeight = 1000.0;
+
 let scores = {};
+
+let lastChar = ' ';
+let lastScore = 0.0;
 
 export function updateScore(char, isCorrect) {
   let score = 0.0;
@@ -33,6 +38,17 @@ export function updateScore(char, isCorrect) {
   }
   // Keep an exponential moving average of the score over time.
   scores[char] = score * adjustRate + scores[char] * (1 - adjustRate);
+
+  const pair = lastChar + char;
+  const pairScore = score + lastScore;
+  lastChar = char;
+  lastScore = score;
+  if (!(pair in scores)) {
+    scores[pair] = defaultScore * 2;
+  }
+  scores[pair] = pairScore * adjustRate + scores[pair] * (1 - adjustRate);
+
+  console.log(scores);
 }
 
 export function getWord(wordset) {
@@ -42,6 +58,7 @@ export function getWord(wordset) {
     let newWord = wordset[Math.floor(Math.random() * wordset.length)];
     let newScore = score(newWord);
     if (i == 0 || newScore > highScore) {
+      console.log("score: " + newWord + " = " + newScore);
       randomWord = newWord;
       highScore = newScore;
     }
@@ -51,8 +68,12 @@ export function getWord(wordset) {
 
 function score(word) {
   let total = 0.0;
+  let prev = ' ';
   for (const c of word) {
-    total += c in scores ? scores[c] : defaultScore;
+    //total += c in scores ? scores[c] : defaultScore;
+    const pair = prev + c;
+    total += (pair in scores ? scores[pair] : defaultScore * 2) * pairWeight;
+    prev = c;
   }
   return total / word.length;
 }


### PR DESCRIPTION
### Description
Improvements to weakspot.

Gets rid of `defaultScore` (which was hacky), instead makes the learning rate faster at the start so that it's a simple mean for the first `perCharCount` of each letter and an exponential average afterwards. Chars that haven't been seen at all don't contribute to a word's score.

The effect should be that it seems "fairer" with only a small amount of input.

### Checklist 
- [x] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/Miodec/monkeytype/blob/master/CODE_OF_CONDUCT.md) and the [`CONTRIBUTING.md`](https://github.com/Miodec/monkeytype/blob/master/CONTRIBUTING.md)
- [x] I checked if my PR has any bugs or other issues that could reduce the stability of the project
- [x] I understand that the maintainer has the right to reject my contribution and it may not get accepted.
