### PR TITLE
Add Github theme (light, dimmed and dark variants)

### DIFF
--- a/static/themes/_list.json
+++ b/static/themes/_list.json
@@ -573,5 +573,20 @@
     "name": "material",
     "bgColor": "#263238",
     "textColor": "#80cbc4"
-  }
+  },
+	{
+    "name": "github_dark",
+    "bgColor": "#0d1117",
+    "textColor": "#f0f6fc"
+	},
+	{
+    "name": "github_dimmed",
+    "bgColor": "#22272e",
+    "textColor": "#cdd9e5"
+	},
+	{
+    "name": "github_light",
+    "bgColor": "#fafbfc",
+    "textColor": "#2f363d"
+	}
 ]

--- a/static/themes/github_dark.css
+++ b/static/themes/github_dark.css
@@ -1,0 +1,15 @@
+:root {
+  --bg-color: #0d1117;
+  --main-color: #f0f6fc;
+  --caret-color: #f0f6fc;
+  --sub-color: #6e7681;
+  --text-color: #f0f6fc;
+  --error-color: #f85149;
+  --error-extra-color: #f85149;
+  --colorful-error-color: #f85149;
+  --colorful-error-extra-color: #f85149;
+}
+
+#menu .icon-button {
+  color: #6e7681;
+}

--- a/static/themes/github_dimmed.css
+++ b/static/themes/github_dimmed.css
@@ -1,0 +1,15 @@
+:root {
+  --bg-color: #22272e;
+  --main-color: #cdd9e5;
+  --caret-color: #cdd9e5;
+  --sub-color: #636e7b;
+  --text-color: #cdd9e5;
+  --error-color: #e5534b;
+  --error-extra-color: #e5534b;
+  --colorful-error-color: #e5534b;
+  --colorful-error-extra-color: #e5534b;
+}
+
+#menu .icon-button {
+  color: #636e7b;
+}

--- a/static/themes/github_light.css
+++ b/static/themes/github_light.css
@@ -1,0 +1,15 @@
+:root {
+  --bg-color: #fafbfc;
+  --main-color: #2f363d;
+  --caret-color: #2f363d;
+  --sub-color: #d1d5da;
+  --text-color: #2f363d;
+  --error-color: #f97583;
+  --error-extra-color: #f97583;
+  --colorful-error-color: #f97583;
+  --colorful-error-extra-color: #f97583;
+}
+
+#menu .icon-button {
+  color: #d1d5da;
+}


### PR DESCRIPTION
Added Github Theme in three variants (light, dimmed and dark)

### Description
<!-- Please describe the change(s) made in your PR -->

These themes are using [Primer's color system](https://primer.style/css/support/color-system), the same used in the Github Theme extension for VSCode.

#### Variants
- Light

![github_light](https://user-images.githubusercontent.com/47466248/128538094-fe2fd989-47ef-4886-8bd3-caa61b69d222.png)

- Dimmed

![github_dimmed](https://user-images.githubusercontent.com/47466248/128538196-55ec20b6-2da7-4c38-ad74-cc96d0485f8f.png)

- Dark

![github_dark](https://user-images.githubusercontent.com/47466248/128538306-95cf8189-7aa2-4919-92fc-975637831a1a.png)
