### PR TITLE
Fix slider thumbs on firefox

### DIFF
--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -52,9 +52,11 @@ input[type="range"] {
   width: 100%;
   height: 1rem;
   border-radius: var(--roundness);
-  &::-webkit-slider-thumb {
+  &::-webkit-slider-thumb,
+  &::-moz-range-thumb {
     -webkit-appearance: none;
     padding: 0;
+    border: none;
     width: 2rem;
     height: 1rem;
     border-radius: var(--roundness);


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

<!-- Please describe the change(s) made in your PR -->

<!-- please check the items you have completed -->

Fixed range slider thumbs looking weird on firefox. They now have the same styling as in chrome.

![image](https://user-images.githubusercontent.com/34758569/130337908-c6102985-a983-4e8c-a613-84391f92b561.png)

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/Miodec/monkeytype/pull/1234) -->
