### PR TITLE
Add exit condition for username loop

### DIFF
--- a/src/js/account-controller.js
+++ b/src/js/account-controller.js
@@ -103,6 +103,7 @@ export async function signInWithGoogle() {
 
         if (name == null) {
           AccountController.signOut();
+          $(".pageLogin .preloader").addClass("hidden");
           return;
         }
 

--- a/src/js/account-controller.js
+++ b/src/js/account-controller.js
@@ -2,6 +2,7 @@ import * as Notifications from "./notifications";
 import * as UpdateConfig from "./config";
 import * as AccountButton from "./account-button";
 import * as Account from "./account";
+import * as AccountController from "./account-controller";
 import * as CommandlineLists from "./commandline-lists";
 import * as VerificationController from "./verification-controller";
 import * as Misc from "./misc";
@@ -99,6 +100,11 @@ export async function signInWithGoogle() {
         name = await prompt(
           "Please provide a new username (cannot be longer than 16 characters, can only contain letters, numbers, underscores, dots and dashes):"
         );
+
+        if (name == null) {
+          AccountController.signOut();
+          return;
+        }
 
         let response;
         try {

--- a/src/js/account.js
+++ b/src/js/account.js
@@ -93,6 +93,11 @@ export async function getDataAndInit() {
           "Please provide a new username (cannot be longer than 16 characters, can only contain letters, numbers, underscores, dots and dashes):"
         );
 
+        if (name == null) {
+          AccountController.signOut();
+          return;
+        }
+
         let response;
         try {
           response = await axiosInstance.post("/user/updateName", { name });


### PR DESCRIPTION
### Description
<!-- Please describe the change(s) made in your PR -->
When user uses Google Sign In to login for the first time, he is prompted to choose a username. If prompt is closed (cancel pressed), request is sent with `{name: null}`. Check fails and prompt reappears. User is now stuck in this loop, unless a valid username is provided. There might be reasons why user would choose not to proceed with this, so let's provide an option not to. If prompt is closed, break the loop and sign out.
