### PR TITLE
add time and date of when screenshot was taken

### DIFF
--- a/src/js/test/test-ui.js
+++ b/src/js/test/test-ui.js
@@ -209,13 +209,13 @@ export async function screenshot() {
   $("#resultReplay").addClass("hidden");
   $(".pageTest .ssWatermark").removeClass("hidden");
   $(".pageTest .ssWatermark").text(
-    new Date().toLocaleString() + " | monkeytype.com "
+    moment(Date.now()).format("DD MMM YYYY HH:mm") + " | monkeytype.com "
   );
   if (firebase.auth().currentUser != null) {
     $(".pageTest .ssWatermark").text(
       DB.getSnapshot().name +
         " | " +
-        new Date().toLocaleString() +
+        moment(Date.now()).format("DD MMM YYYY HH:mm") +
         " | monkeytype.com  "
     );
   }

--- a/src/js/test/test-ui.js
+++ b/src/js/test/test-ui.js
@@ -208,9 +208,15 @@ export async function screenshot() {
   }
   $("#resultReplay").addClass("hidden");
   $(".pageTest .ssWatermark").removeClass("hidden");
+  $(".pageTest .ssWatermark").text(
+    new Date().toLocaleString() + " | monkeytype.com "
+  );
   if (firebase.auth().currentUser != null) {
     $(".pageTest .ssWatermark").text(
-      DB.getSnapshot().name + " | monkeytype.com"
+      DB.getSnapshot().name +
+        " | " +
+        new Date().toLocaleString() +
+        " | monkeytype.com  "
     );
   }
   $(".pageTest .buttons").addClass("hidden");


### PR DESCRIPTION
Signed-off-by: Alexander Johansen <odyssey346@disroot.org>

<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

This adds date and time of when a screenshot was taken using the Screenshot button in Monkeytype. This fixes #1781. 
 
It's a bit buggy, sometimes text starts clipping out of screenshot. I'll see if I can fix that
Closes #1781

![image](https://user-images.githubusercontent.com/57069715/131291680-eea580cc-292e-4b9f-ab60-7267aeeee3fc.png)


<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->
#1781
<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/Miodec/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
