### PR TITLE
Fix bug in update name time limit

### DIFF
--- a/backend/dao/user.js
+++ b/backend/dao/user.js
@@ -21,7 +21,7 @@ class UsersDAO {
       .findOne({ name: { $regex: new RegExp(`^${name}$`, "i") } });
     if (nameDoc) throw new MonkeyError(409, "Username already taken");
     let user = await mongoDB().collection("users").findOne({ uid });
-    if (Date.now() - user.lastNameChange < 2592000) {
+    if (Date.now() - user.lastNameChange < 2592000000) {
       throw new MonkeyError(409, "You can change your name once every 30 days");
     }
     return await mongoDB()


### PR DESCRIPTION
I noticed that the rate limit for changing name on account was incorrectly set to 30 days in seconds, but Date.now() returns milliseconds, so the limit would actually be 0.03 days instead of the intended 30 days.

The only thing I've changed is multiplied the delay by a thousand so that its in milliseconds.

```
30 * 24 * 60 * 60 * 1000
>> 2592000000
```