### PR TITLE
Expose a global replay() function to get replay data

### DIFF
--- a/src/js/exports.js
+++ b/src/js/exports.js
@@ -29,3 +29,5 @@ global.crownTest = async () => {
 global.filterDebug = Account.toggleFilterDebug;
 
 global.stats = TestStats.getStats;
+
+global.replay = Replay.getReplayExport;

--- a/src/js/global-dependencies.js
+++ b/src/js/global-dependencies.js
@@ -24,3 +24,4 @@ import "./ready";
 import "./about-page";
 import * as Account from "./account";
 import * as TestStats from "./test-stats";
+import * as Replay from "./replay";

--- a/src/js/replay.js
+++ b/src/js/replay.js
@@ -256,6 +256,13 @@ function playReplay() {
   );
 }
 
+function getReplayExport() {
+  return JSON.stringify({
+    replayData: replayData,
+    wordsList: wordsList,
+  });
+}
+
 $(".pageTest #playpauseReplayButton").click(async (event) => {
   if (toggleButton.className === "fas fa-play") {
     playReplay();
@@ -293,4 +300,5 @@ export {
   stopReplayRecording,
   addReplayEvent,
   replayGetWordsList,
+  getReplayExport,
 };


### PR DESCRIPTION
### Description

Expose a global replay() function to get replay data

This allows the data to be exported for analysis using the console, e.g.
with `copy(replay())`.  I expect it can be used in future as the basis
for the "ttr" file described in the TODO.

As discussed with mio on discord #development