### PR TITLE
fix color input borders on firefox

### DIFF
--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -90,7 +90,8 @@ input[type="color"]::-webkit-color-swatch-wrapper {
   padding: 0;
 }
 
-input[type="color"]::-webkit-color-swatch {
+input[type="color"]::-webkit-color-swatch,
+::-moz-color-swatch {
   border: none;
 }
 


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

<!-- Please describe the change(s) made in your PR -->

Fixes white borders around color inputs on firefox.

Before:

![image](https://user-images.githubusercontent.com/34758569/132251921-5abf9fc0-d250-4a84-b7d4-1d88bab01365.png)

After:

![image](https://user-images.githubusercontent.com/34758569/132251916-cf8084e8-d8a5-4ec5-82fa-ec395840680a.png)


<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/Miodec/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
