### PR TITLE
Fixed spanish 'á' character in quote source

### DIFF
--- a/static/quotes/english.json
+++ b/static/quotes/english.json
@@ -9675,7 +9675,7 @@
     },
     {
       "text": "I don't know what is going to happen next year, no one does. But that's OK. I can handle it, I decide. It's just a harder gear, and I am ready. All I have to do is take a deep breath and ride.",
-      "source": "Merci SuÃ¡rez Changes Gears",
+      "source": "Merci Suárez Changes Gears",
       "id": 1630,
       "length": 192
     },


### PR DESCRIPTION
### Description

Fixed a Spanish character that was wrong, probably encoding weirdness from a copy paste or something.
