### PR TITLE
Remove extra space in "Sign In" link

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1140,9 +1140,7 @@
                 <canvas id="wpmChart"></canvas>
               </div>
               <div class="loginTip">
-                <span class="link" style="text-decoration: underline">
-                  Sign in
-                </span>
+                <span class="link" style="text-decoration: underline">Sign in</span>
                 to save your result
               </div>
               <div class="bottom" style="grid-column: 1/3">


### PR DESCRIPTION
### Description

HTML treats newlines as whitespace and collapses it + the spaces down to a single space which has the underline. This fixes this by tightening up the `<span>`s

![image](https://user-images.githubusercontent.com/9407960/133580961-10b1dd6b-32c9-4ed2-b744-fa0a12f3ffd4.png)

to

![image](https://user-images.githubusercontent.com/9407960/133581009-d7d5598b-8709-44b1-adb5-65f84ed9bdd8.png)

