### PR TITLE
Add JetBrains Mono font

### DIFF
--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Fira+Code&family=IBM+Plex+Sans:wght@600&family=Inconsolata&family=Roboto+Mono&family=Source+Code+Pro&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Fira+Code&family=IBM+Plex+Sans:wght@600&family=Inconsolata&family=Roboto+Mono&family=Source+Code+Pro&family=JetBrains+Mono&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Montserrat&family=Roboto&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Titillium+Web&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Lexend+Deca&display=swap");

--- a/static/fonts/_list.json
+++ b/static/fonts/_list.json
@@ -15,6 +15,9 @@
     "name": "Fira Code"
   },
   {
+    "name": "JetBrains Mono"
+  },
+  {
     "name": "Roboto"
   },
   {


### PR DESCRIPTION
This PR adds the [JetBrains Mono](https://www.jetbrains.com/lp/mono/) font hosted on [Google Fonts](https://fonts.google.com/specimen/JetBrains+Mono)