### PR TITLE
fix background color input border

### DIFF
--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -135,7 +135,7 @@ input[type="number"] {
   }
 
   & #--bg-color {
-    border: 1px solid var(--sub-color);
+    border: 2px solid var(--sub-color);
   }
 }
 


### PR DESCRIPTION
changed background color input border to 2px to match danger zone buttons
![image](https://user-images.githubusercontent.com/34758569/134817834-0d3a1e08-c54f-468a-9703-3853271a4c76.png)
![image](https://user-images.githubusercontent.com/34758569/134817843-f0d8c173-e0df-4ee2-b5d9-6daeb53bd6af.png)
