### PR TITLE
Fix quote search popup width

### DIFF
--- a/src/sass/popups.scss
+++ b/src/sass/popups.scss
@@ -400,7 +400,7 @@
     padding: 2rem;
     display: grid;
     gap: 1rem;
-    width: 1000px;
+    width: 80vw;
     height: 80vh;
     grid-template-rows: auto auto auto 1fr;
 

--- a/src/sass/popups.scss
+++ b/src/sass/popups.scss
@@ -401,6 +401,7 @@
     display: grid;
     gap: 1rem;
     width: 80vw;
+    max-width: 1000px;
     height: 80vh;
     grid-template-rows: auto auto auto 1fr;
 


### PR DESCRIPTION
Makes the width of the quote search responsive to the width of the screen

This is how it looks currently:
![image](https://user-images.githubusercontent.com/55359963/135896617-3578ace7-3c15-45ea-a0dc-45e8da9b0973.png)

This is how it would look:
![image](https://user-images.githubusercontent.com/55359963/135896679-5b2ea82e-d16f-4f6d-9f99-2c4363ae9fb6.png)

(The window is the same size across the screenshots.)
