### PR TITLE
Make Tab and Esc behavior consistent even with swap

### DIFF
--- a/src/js/input-controller.js
+++ b/src/js/input-controller.js
@@ -570,12 +570,15 @@ function focusRestartOrRestart(event) {
     }
 
     if (Config.quickTab) {
-      if (event.shiftKey) {
-        ManualRestart.set();
+      if (event.key === "Tab") {
+        if (event.shiftKey) {
+          ManualRestart.set();
+        } else {
+          ManualRestart.reset();
+        }
       } else {
-        ManualRestart.reset();
+        ManualRestart.set();
       }
-
       if (
         TestLogic.active &&
         Config.repeatQuotes === "typing" &&

--- a/src/js/input-controller.js
+++ b/src/js/input-controller.js
@@ -546,22 +546,6 @@ function handleChar(char, charIndex) {
 }
 
 function focusRestartOrRestart(event) {
-  if (Config.quickTab) {
-    if (
-      TestLogic.active &&
-      Config.repeatQuotes === "typing" &&
-      Config.mode === "quote"
-    ) {
-      TestLogic.restart(true, false, event);
-    } else {
-      TestLogic.restart(false, false, event);
-    }
-  } else if (!TestUI.resultVisible) {
-    $("#restartTestButton").focus();
-  }
-}
-
-function handleTab(event) {
   if (TestUI.resultCalculating) {
     event.preventDefault();
   }
@@ -585,23 +569,25 @@ function handleTab(event) {
       event.preventDefault();
     }
 
-    if (event.key == "Tab") {
-      if ((TestLogic.hasTab || Config.mode === "zen") && !event.shiftKey) {
-        handleChar("\t", TestLogic.input.current.length);
-        setWordsInput(" " + TestLogic.input.current);
-        return;
+    if (Config.quickTab) {
+      if (event.shiftKey) {
+        ManualRestart.set();
+      } else {
+        ManualRestart.reset();
       }
 
-      if (Config.quickTab) {
-        if (event.shiftKey) {
-          ManualRestart.set();
-        } else {
-          ManualRestart.reset();
-        }
+      if (
+        TestLogic.active &&
+        Config.repeatQuotes === "typing" &&
+        Config.mode === "quote"
+      ) {
+        TestLogic.restart(true, false, event);
+      } else {
+        TestLogic.restart(false, false, event);
       }
+    } else if (!TestUI.resultVisible) {
+      $("#restartTestButton").focus();
     }
-
-    focusRestartOrRestart(event);
   } else if (Config.quickTab) {
     UI.changePage("test");
   }
@@ -652,12 +638,14 @@ $(document).keydown((event) => {
     }
   }
 
-  //tab
-  if (
-    (event.key == "Tab" && !Config.swapEscAndTab) ||
-    (event.key == "Escape" && Config.swapEscAndTab)
-  ) {
-    handleTab(event);
+  //tab/esc
+  if (event.key === "Tab" && (TestLogic.hasTab || Config.mode === "zen") && !event.shiftKey) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    handleChar("\t", TestLogic.input.current.length);
+    setWordsInput(" " + TestLogic.input.current);
+  } else if ((event.key === "Tab" && !Config.swapEscAndTab) || (event.key === "Escape" && Config.swapEscAndTab)) {
+    focusRestartOrRestart(event);
   }
 
   if (!allowTyping) return;

--- a/src/js/input-controller.js
+++ b/src/js/input-controller.js
@@ -565,47 +565,34 @@ function handleTab(event) {
   ) return;
 
   if ($(".pageTest").hasClass("active")) {
+    if ((TestLogic.hasTab || Config.mode === "zen") && !event.shiftKey) {
+      event.preventDefault();
+      handleChar("\t", TestLogic.input.current.length);
+      setWordsInput(" " + TestLogic.input.current);
+      return;
+    }
+
     if (Config.quickTab) {
-      if (
-        TestUI.resultVisible ||
-        !(
-          (Config.mode == "zen" && !event.shiftKey) ||
-          (TestLogic.hasTab && !event.shiftKey)
-        )
-      ) {
-        if (event.shiftKey) {
-          ManualRestart.set();
-        } else {
-          ManualRestart.reset();
-        }
-        event.preventDefault();
-        if (
-          TestLogic.active &&
-          Config.repeatQuotes === "typing" &&
-          Config.mode === "quote"
-        ) {
-          TestLogic.restart(true, false, event);
-        } else {
-          TestLogic.restart(false, false, event);
-        }
+      event.preventDefault();
+
+      if (event.shiftKey) {
+        ManualRestart.set();
       } else {
-        event.preventDefault();
-        handleChar("\t", TestLogic.input.current.length);
-        setWordsInput(" " + TestLogic.input.current);
+        ManualRestart.reset();
       }
-    } else if (!TestUI.resultVisible) {
+
       if (
-        (TestLogic.hasTab && event.shiftKey) ||
-        (!TestLogic.hasTab && Config.mode !== "zen") ||
-        (Config.mode === "zen" && event.shiftKey)
+        TestLogic.active &&
+        Config.repeatQuotes === "typing" &&
+        Config.mode === "quote"
       ) {
-        event.preventDefault();
-        $("#restartTestButton").focus();
+        TestLogic.restart(true, false, event);
       } else {
-        event.preventDefault();
-        handleChar("\t", TestLogic.input.current.length);
-        setWordsInput(" " + TestLogic.input.current);
+        TestLogic.restart(false, false, event);
       }
+    } else if (!TestUI.resultVisible){
+      event.preventDefault();
+      $("#restartTestButton").focus();
     }
   } else if (Config.quickTab) {
     UI.changePage("test");

--- a/src/js/input-controller.js
+++ b/src/js/input-controller.js
@@ -545,6 +545,22 @@ function handleChar(char, charIndex) {
 
 }
 
+function focusRestartOrRestart(event) {
+  if (Config.quickTab) {
+    if (
+      TestLogic.active &&
+      Config.repeatQuotes === "typing" &&
+      Config.mode === "quote"
+    ) {
+      TestLogic.restart(true, false, event);
+    } else {
+      TestLogic.restart(false, false, event);
+    }
+  } else if (!TestUI.resultVisible) {
+    $("#restartTestButton").focus();
+  }
+}
+
 function handleTab(event) {
   if (TestUI.resultCalculating) {
     event.preventDefault();
@@ -565,35 +581,27 @@ function handleTab(event) {
   ) return;
 
   if ($(".pageTest").hasClass("active")) {
-    if ((TestLogic.hasTab || Config.mode === "zen") && !event.shiftKey) {
+    if (!TestUI.resultVisible) {
       event.preventDefault();
-      handleChar("\t", TestLogic.input.current.length);
-      setWordsInput(" " + TestLogic.input.current);
-      return;
     }
 
-    if (Config.quickTab) {
-      event.preventDefault();
-
-      if (event.shiftKey) {
-        ManualRestart.set();
-      } else {
-        ManualRestart.reset();
+    if (event.key == "Tab") {
+      if ((TestLogic.hasTab || Config.mode === "zen") && !event.shiftKey) {
+        handleChar("\t", TestLogic.input.current.length);
+        setWordsInput(" " + TestLogic.input.current);
+        return;
       }
 
-      if (
-        TestLogic.active &&
-        Config.repeatQuotes === "typing" &&
-        Config.mode === "quote"
-      ) {
-        TestLogic.restart(true, false, event);
-      } else {
-        TestLogic.restart(false, false, event);
+      if (Config.quickTab) {
+        if (event.shiftKey) {
+          ManualRestart.set();
+        } else {
+          ManualRestart.reset();
+        }
       }
-    } else if (!TestUI.resultVisible){
-      event.preventDefault();
-      $("#restartTestButton").focus();
     }
+
+    focusRestartOrRestart(event);
   } else if (Config.quickTab) {
     UI.changePage("test");
   }

--- a/src/js/input-controller.js
+++ b/src/js/input-controller.js
@@ -556,58 +556,59 @@ function handleTab(event) {
     event.preventDefault();
     return;
   }
-  if (
+
+  if (!(
     !TestUI.resultCalculating &&
     $("#commandLineWrapper").hasClass("hidden") &&
     $("#simplePopupWrapper").hasClass("hidden") &&
-    !$(".page.pageLogin").hasClass("active")
-  ) {
-    if ($(".pageTest").hasClass("active")) {
-      if (Config.quickTab) {
-        if (
-          TestUI.resultVisible ||
-          !(
-            (Config.mode == "zen" && !event.shiftKey) ||
-            (TestLogic.hasTab && !event.shiftKey)
-          )
-        ) {
-          if (event.shiftKey) {
-            ManualRestart.set();
-          } else {
-            ManualRestart.reset();
-          }
-          event.preventDefault();
-          if (
-            TestLogic.active &&
-            Config.repeatQuotes === "typing" &&
-            Config.mode === "quote"
-          ) {
-            TestLogic.restart(true, false, event);
-          } else {
-            TestLogic.restart(false, false, event);
-          }
+    !$(".page.pageLogin").hasClass("active"))
+  ) return;
+
+  if ($(".pageTest").hasClass("active")) {
+    if (Config.quickTab) {
+      if (
+        TestUI.resultVisible ||
+        !(
+          (Config.mode == "zen" && !event.shiftKey) ||
+          (TestLogic.hasTab && !event.shiftKey)
+        )
+      ) {
+        if (event.shiftKey) {
+          ManualRestart.set();
         } else {
-          event.preventDefault();
-          handleChar("\t", TestLogic.input.current.length);
-          setWordsInput(" " + TestLogic.input.current);
+          ManualRestart.reset();
         }
-      } else if (!TestUI.resultVisible) {
+        event.preventDefault();
         if (
-          (TestLogic.hasTab && event.shiftKey) ||
-          (!TestLogic.hasTab && Config.mode !== "zen") ||
-          (Config.mode === "zen" && event.shiftKey)
+          TestLogic.active &&
+          Config.repeatQuotes === "typing" &&
+          Config.mode === "quote"
         ) {
-          event.preventDefault();
-          $("#restartTestButton").focus();
+          TestLogic.restart(true, false, event);
         } else {
-          event.preventDefault();
-          handleChar("\t", TestLogic.input.current.length);
-          setWordsInput(" " + TestLogic.input.current);
+          TestLogic.restart(false, false, event);
         }
+      } else {
+        event.preventDefault();
+        handleChar("\t", TestLogic.input.current.length);
+        setWordsInput(" " + TestLogic.input.current);
       }
-    } else if (Config.quickTab) {
-      UI.changePage("test");
+    } else if (!TestUI.resultVisible) {
+      if (
+        (TestLogic.hasTab && event.shiftKey) ||
+        (!TestLogic.hasTab && Config.mode !== "zen") ||
+        (Config.mode === "zen" && event.shiftKey)
+      ) {
+        event.preventDefault();
+        $("#restartTestButton").focus();
+      } else {
+        event.preventDefault();
+        handleChar("\t", TestLogic.input.current.length);
+        setWordsInput(" " + TestLogic.input.current);
+      }
     }
+  } else if (Config.quickTab) {
+    UI.changePage("test");
   }
 }
 

--- a/src/js/input-controller.js
+++ b/src/js/input-controller.js
@@ -556,23 +556,7 @@ function handleTab(event) {
     event.preventDefault();
     return;
   }
-  if ($("#customTextPopup .textarea").is(":focus")) {
-    event.preventDefault();
-
-    let area = $("#customTextPopup .textarea")[0];
-
-    var start = area.selectionStart;
-    var end = area.selectionEnd;
-
-    // set textarea value to: text before caret + tab + text after caret
-    area.value =
-      area.value.substring(0, start) + "\t" + area.value.substring(end);
-
-    // put caret at right position again
-    area.selectionStart = area.selectionEnd = start + 1;
-
-    return;
-  } else if (
+  if (
     !TestUI.resultCalculating &&
     $("#commandLineWrapper").hasClass("hidden") &&
     $("#simplePopupWrapper").hasClass("hidden") &&
@@ -626,6 +610,23 @@ function handleTab(event) {
     }
   }
 }
+
+$("#customTextPopup .textarea").keydown((event) => {
+  if (event.key !== "Tab") return;
+
+  event.preventDefault();
+  event.stopImmediatePropagation();
+  let area = event.target;
+  var start = area.selectionStart;
+  var end = area.selectionEnd;
+
+  // set textarea value to: text before caret + tab + text after caret
+  area.value =
+    area.value.substring(0, start) + "\t" + area.value.substring(end);
+
+  // put caret at right position again
+  area.selectionStart = area.selectionEnd = start + 1;
+})
 
 $(document).keydown((event) => {
   //autofocus

--- a/src/js/test/test-logic.js
+++ b/src/js/test/test-logic.js
@@ -834,7 +834,7 @@ export function restart(
       ) {
         let message = "Use your mouse to confirm.";
         if (Config.quickTab)
-          message = "Press shift + tab or use your mouse to confirm.";
+          message = `Press shift + ${Config.swapEscAndTab ? "esc" : "tab"} or use your mouse to confirm.`;
         Notifications.add("Quick restart disabled. " + message, 0, 3);
         return;
       }

--- a/src/js/test/test-ui.js
+++ b/src/js/test/test-ui.js
@@ -494,7 +494,7 @@ export function updateModesNotice() {
 
   if (TestLogic.hasTab) {
     $(".pageTest #testModesNotice").append(
-      `<div class="text-button"><i class="fas fa-long-arrow-alt-right"></i>shift + tab to restart</div>`
+      `<div class="text-button"><i class="fas fa-long-arrow-alt-right"></i>shift + tab to ${Config.swapEscAndTab ? "open command line" : "restart"}</div>`
     );
   }
 


### PR DESCRIPTION
Edit: This PR also refactors and cleans up some messy code I left in after input rewrite

---

When typing in zen mode or a quote that contains a tab character:
### Before
#### No swapEscAndTab
* **Tab**: Inputs tab character
    * **Shift + Tab**: Selects restart button (or restarts with quick tab)
* **Escape**: Opens command line

All good.

#### With swapEscAndTab
* **Tab**: Opens command line
* **Escape**: Inputs tab character
    * **Shift + Escape**: Selects restart button (or restarts with quick tab)

Makes sense, it literally "swaps" all of their behavior, but is unintuitive.

### After
#### No swapEscAndTab
Same as before.

#### With swapEscAndTab
* **Tab**: Inputs tab character
    * **Shift + Tab**: Opens command line
* **Escape**: Selects restart button (or restarts with quick tab)

Main functionality is swapped, but Tab still inserts a tab character. More intuitive.

