### PR TITLE
Fix results page stats css for mobile

### DIFF
--- a/src/sass/media-queries.scss
+++ b/src/sass/media-queries.scss
@@ -293,22 +293,6 @@
       }
     }
   }
-  #middle {
-    #result {
-      grid-template-areas:
-        "stats stats"
-        "chart chart"
-        "morestats morestats";
-      .stats {
-        grid-template-areas: "wpm acc burst";
-        gap: 4rem;
-      }
-      .stats.morestats {
-        grid-template-rows: 1fr 1fr 1fr;
-        gap: 1rem;
-      }
-    }
-  }
   #bottom {
     .leftright {
       .left {
@@ -356,22 +340,6 @@
     .group .buttons {
       font-size: 0.65rem;
       line-height: 0.65rem;
-    }
-  }
-  #middle {
-    #result {
-      grid-template-areas:
-        "stats stats"
-        "chart chart"
-        "morestats morestats";
-      .stats {
-        grid-template-areas: "wpm acc burst";
-        gap: 4rem;
-      }
-      .stats.morestats {
-        grid-template-rows: 1fr 1fr 1fr;
-        gap: 1rem;
-      }
     }
   }
   #bottom {


### PR DESCRIPTION
### Description
I changed css media queries on smaller screens to display wpm and acc stats side by side instead of on top of each other. Used code that already existed for doing this at a larger size, which was not copied for smaller sizes for some reason.

Before:
![Screenshot from 2021-10-09 04-28-40](https://user-images.githubusercontent.com/47042841/136650801-d4697e22-06e0-4e0d-bff9-af3d3648a0cd.png)
After:
![Screenshot from 2021-10-09 04-27-54](https://user-images.githubusercontent.com/47042841/136650804-f256d1a3-2c65-4c52-9bfc-a026d613dd33.png)

Also, note that there are still some issues with mobile ui that should probably be fixed, but I just wanted to get this one commit in. For example, test type selection is cut off and buttons below results don't use all the space they are afforded.