### PR TITLE
Run GitHub action on merges to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,14 @@ permissions:
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [closed]
+
+concurrency: push-to-${{github.ref}}
 
 jobs:
   lint_and_format:
     name: Lint and auto-format
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:
@@ -17,12 +20,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{github.event.pull_request.base.sha}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
       - run: |
-          git pull origin ${{github.event.pull_request.head.ref}} --rebase
-          git checkout ${{github.event.pull_request.head.ref}}
-
-
+          git pull origin ${{github.event.pull_request.base.ref}}
+          git checkout ${{github.event.pull_request.base.ref}}
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v2.3.0
@@ -39,10 +39,10 @@ jobs:
       - name: Run Prettier
         run: npx pretty-quick --branch ${{github.event.pull_request.base.sha}}
 
-#       - name: Commit and push
-#         run: |
-#           git config user.name "GitHub Actions Bot"
-#           git config user.email "<>"
-#           git add --update
-#           git commit -m "Auto-format with Prettier" || :
-#           git push origin HEAD:${{github.event.pull_request.head.ref}}
+      - name: Commit and push
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "<>"
+          git add --update
+          git commit -m "Auto-format with Prettier" || :
+          git push origin HEAD:${{github.event.pull_request.base.ref}}


### PR DESCRIPTION
### Description
Not as good as what we wanted but at least this one works.

1. Merge pull request
2. Action auto-formats with Prettier
    * Commits directly to master under "GitHub Actions" name, right after merge commit.
        * This can cause problems if multiple actions run at the same time, as some actions will be left behind and won't be able to push. The [concurrency](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency) field I set partially solves this, but currently it only allows having up to 1 action in the queue, so if you merge more than 2 PRs at the same time some of the actions will be dropped. If you don't merge many PRs at the same time this won't be a problem.
3.  Lints everything. If it finds an error, nothing will be changed but you'll receive an e-mail telling you something's wrong and you'll have to check it out manually.

Edit: You'll have to constantly be pulling from master to catch up with the action's commit. I can understand if you don't like this approach and would rather auto-format manually (or not at all).

Edit 2: Actually, I'm not sure if github bots have more power and can push to fork pull requests? Maybe we could run a bot in the same instance as the site database and have that one auto format and even comment on people's PRs? I'll have to look into that.