### PR TITLE
Settings from URL

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -184,6 +184,8 @@ const refactoredSrc = [
   "./src/js/test/wordset.js",
   "./src/js/test/tts.js",
   "./src/js/replay.js",
+
+  "./src/js/url.js",
 ];
 
 //legacy files

--- a/src/js/account-controller.js
+++ b/src/js/account-controller.js
@@ -1,11 +1,10 @@
 import * as Notifications from "./notifications";
-import Config, * as UpdateConfig from "./config";
+import * as UpdateConfig from "./config";
 import * as AccountButton from "./account-button";
 import * as Account from "./account";
 import * as AccountController from "./account-controller";
 import * as CommandlineLists from "./commandline-lists";
 import * as VerificationController from "./verification-controller";
-import * as Misc from "./misc";
 import * as Settings from "./settings";
 import * as AllTimeStats from "./all-time-stats";
 import * as DB from "./db";

--- a/src/js/account-controller.js
+++ b/src/js/account-controller.js
@@ -66,22 +66,6 @@ const authListener = firebase.auth().onAuthStateChanged(async function (user) {
     UI.setPageTransition(false);
     if ($(".pageLoading").hasClass("active")) UI.changePage("");
   }
-  let theme = Misc.findGetParameter("customTheme");
-  if (theme !== null) {
-    try {
-      theme = theme.split(",");
-      UpdateConfig.setCustomThemeColors(theme);
-      Notifications.add("Custom theme applied.", 1);
-    } catch (e) {
-      Notifications.add(
-        "Something went wrong. Reverting to default custom colors.",
-        0
-      );
-      UpdateConfig.setCustomThemeColors(Config.defaultConfig.customThemeColors);
-    }
-    UpdateConfig.setCustomTheme(true);
-    Settings.setCustomThemeInputs();
-  }
   if (/challenge_.+/g.test(window.location.pathname)) {
     Notifications.add(
       "Challenge links temporarily disabled. Please use the command line to load the challenge manually",

--- a/src/js/commandline-lists.js
+++ b/src/js/commandline-lists.js
@@ -39,7 +39,7 @@ function canBailOut() {
   );
 }
 
-let commandsLayouts = {
+export let commandsLayouts = {
   title: "Layout emulator...",
   configKey: "layout",
   list: [
@@ -103,7 +103,7 @@ if (Object.keys(layouts).length > 0) {
   });
 }
 
-let commandsLanguages = {
+export let commandsLanguages = {
   title: "Language...",
   configKey: "language",
   list: [
@@ -129,7 +129,7 @@ Misc.getLanguageList().then((languages) => {
   });
 });
 
-let commandsFunbox = {
+export let commandsFunbox = {
   title: "Funbox...",
   configKey: "funbox",
   list: [
@@ -162,7 +162,7 @@ Misc.getFunboxList().then((funboxes) => {
   });
 });
 
-let commandsFonts = {
+export let commandsFonts = {
   title: "Font family...",
   configKey: "fontFamily",
   list: [],
@@ -196,7 +196,7 @@ Misc.getFontsList().then((fonts) => {
   });
 });
 
-let commandsTags = {
+export let commandsTags = {
   title: "Change tags...",
   list: [],
 };
@@ -261,7 +261,7 @@ export function updateTagCommands() {
   }
 }
 
-let commandsPresets = {
+export let commandsPresets = {
   title: "Presets...",
   list: [],
 };
@@ -285,7 +285,7 @@ export function updatePresetCommands() {
   }
 }
 
-let commandsRepeatQuotes = {
+export let commandsRepeatQuotes = {
   title: "Repeat quotes...",
   configKey: "repeatQuotes",
   list: [
@@ -308,7 +308,7 @@ let commandsRepeatQuotes = {
   ],
 };
 
-let commandsLiveWpm = {
+export let commandsLiveWpm = {
   title: "Live WPM...",
   configKey: "showLiveWpm",
   list: [
@@ -331,7 +331,7 @@ let commandsLiveWpm = {
   ],
 };
 
-let commandsLiveAcc = {
+export let commandsLiveAcc = {
   title: "Live accuracy...",
   configKey: "showLiveAcc",
   list: [
@@ -354,7 +354,7 @@ let commandsLiveAcc = {
   ],
 };
 
-let commandsLiveBurst = {
+export let commandsLiveBurst = {
   title: "Live burst...",
   configKey: "showLiveBurst",
   list: [
@@ -377,7 +377,7 @@ let commandsLiveBurst = {
   ],
 };
 
-let commandsShowTimer = {
+export let commandsShowTimer = {
   title: "Timer/progress...",
   configKey: "showTimerProgress",
   list: [
@@ -400,7 +400,7 @@ let commandsShowTimer = {
   ],
 };
 
-let commandsKeyTips = {
+export let commandsKeyTips = {
   title: "Key tips...",
   configKey: "showKeyTips",
   list: [
@@ -423,7 +423,7 @@ let commandsKeyTips = {
   ],
 };
 
-let commandsFreedomMode = {
+export let commandsFreedomMode = {
   title: "Freedom mode...",
   configKey: "freedomMode",
   list: [
@@ -446,7 +446,7 @@ let commandsFreedomMode = {
   ],
 };
 
-let commandsStrictSpace = {
+export let commandsStrictSpace = {
   title: "Strict space...",
   configKey: "strictSpace",
   list: [
@@ -469,7 +469,7 @@ let commandsStrictSpace = {
   ],
 };
 
-let commandsBlindMode = {
+export let commandsBlindMode = {
   title: "Blind mode...",
   configKey: "blindMode",
   list: [
@@ -492,7 +492,7 @@ let commandsBlindMode = {
   ],
 };
 
-let commandsShowWordsHistory = {
+export let commandsShowWordsHistory = {
   title: "Always show words history...",
   configKey: "alwaysShowWordsHistory",
   list: [
@@ -515,7 +515,7 @@ let commandsShowWordsHistory = {
   ],
 };
 
-let commandsIndicateTypos = {
+export let commandsIndicateTypos = {
   title: "Indicate typos...",
   configKey: "indicateTypos",
   list: [
@@ -538,7 +538,7 @@ let commandsIndicateTypos = {
   ],
 };
 
-let commandsHideExtraLetters = {
+export let commandsHideExtraLetters = {
   title: "Hide extra letters...",
   configKey: "hideExtraLetters",
   list: [
@@ -561,7 +561,7 @@ let commandsHideExtraLetters = {
   ],
 };
 
-let commandsQuickEnd = {
+export let commandsQuickEnd = {
   title: "Quick end...",
   configKey: "quickEnd",
   list: [
@@ -584,7 +584,7 @@ let commandsQuickEnd = {
   ],
 };
 
-let commandsOppositeShiftMode = {
+export let commandsOppositeShiftMode = {
   title: "Change opposite shift mode...",
   configKey: "oppositeShiftMode",
   list: [
@@ -609,7 +609,7 @@ let commandsOppositeShiftMode = {
   ],
 };
 
-let commandsSoundOnError = {
+export let commandsSoundOnError = {
   title: "Sound on error...",
   configKey: "playSoundOnError",
   list: [
@@ -632,7 +632,7 @@ let commandsSoundOnError = {
   ],
 };
 
-let commandsFlipTestColors = {
+export let commandsFlipTestColors = {
   title: "Flip test colors...",
   configKey: "flipTestColors",
   list: [
@@ -655,7 +655,7 @@ let commandsFlipTestColors = {
   ],
 };
 
-let commandsSmoothLineScroll = {
+export let commandsSmoothLineScroll = {
   title: "Smooth line scroll...",
   configKey: "smoothLineScroll",
   list: [
@@ -678,7 +678,7 @@ let commandsSmoothLineScroll = {
   ],
 };
 
-let commandsAlwaysShowDecimal = {
+export let commandsAlwaysShowDecimal = {
   title: "Always show decimal places...",
   configKey: "alwaysShowDecimalPlaces",
   list: [
@@ -701,7 +701,7 @@ let commandsAlwaysShowDecimal = {
   ],
 };
 
-let commandsAlwaysShowCPM = {
+export let commandsAlwaysShowCPM = {
   title: "Always show CPM...",
   configKey: "alwaysShowCPM",
   list: [
@@ -724,7 +724,7 @@ let commandsAlwaysShowCPM = {
   ],
 };
 
-let commandsStartGraphsAtZero = {
+export let commandsStartGraphsAtZero = {
   title: "Start graphs at zero...",
   configKey: "startGraphsAtZero",
   list: [
@@ -747,7 +747,7 @@ let commandsStartGraphsAtZero = {
   ],
 };
 
-let commandsLazyMode = {
+export let commandsLazyMode = {
   title: "Lazy mode...",
   configKey: "lazyMode",
   list: [
@@ -772,7 +772,7 @@ let commandsLazyMode = {
   ],
 };
 
-let commandsSwapEscAndTab = {
+export let commandsSwapEscAndTab = {
   title: "Swap esc and tab...",
   configKey: "swapEscAndTab",
   list: [
@@ -795,7 +795,7 @@ let commandsSwapEscAndTab = {
   ],
 };
 
-let commandsShowAllLines = {
+export let commandsShowAllLines = {
   title: "Show all lines...",
   configKey: "showAllLines",
   list: [
@@ -818,7 +818,7 @@ let commandsShowAllLines = {
   ],
 };
 
-let commandsColorfulMode = {
+export let commandsColorfulMode = {
   title: "Colorful mode...",
   configKey: "colorfulMode",
   list: [
@@ -841,7 +841,7 @@ let commandsColorfulMode = {
   ],
 };
 
-let commandsOutOfFocusWarning = {
+export let commandsOutOfFocusWarning = {
   title: "Colorful mode...",
   configKey: "showOutOfFocusWarning",
   list: [
@@ -864,7 +864,7 @@ let commandsOutOfFocusWarning = {
   ],
 };
 
-let commandsKeymapMode = {
+export let commandsKeymapMode = {
   title: "Keymap mode...",
   configKey: "keymapMode",
   list: [
@@ -903,7 +903,7 @@ let commandsKeymapMode = {
   ],
 };
 
-let commandsSoundOnClick = {
+export let commandsSoundOnClick = {
   title: "Sound on click...",
   configKey: "playSoundOnClick",
   list: [
@@ -981,7 +981,7 @@ let commandsSoundOnClick = {
   ],
 };
 
-let commandsRandomTheme = {
+export let commandsRandomTheme = {
   title: "Random theme...",
   configKey: "randomTheme",
   list: [
@@ -1028,7 +1028,7 @@ let commandsRandomTheme = {
   ],
 };
 
-let commandsDifficulty = {
+export let commandsDifficulty = {
   title: "Difficulty...",
   configKey: "difficulty",
   list: [
@@ -1090,7 +1090,7 @@ export let commandsEnableAds = {
   ],
 };
 
-let commandsCustomTheme = {
+export let commandsCustomTheme = {
   title: "Custom theme...",
   configKey: "customTheme",
   list: [
@@ -1113,7 +1113,7 @@ let commandsCustomTheme = {
   ],
 };
 
-let commandsCaretStyle = {
+export let commandsCaretStyle = {
   title: "Change caret style...",
   configKey: "caretStyle",
   list: [
@@ -1178,7 +1178,7 @@ let commandsCaretStyle = {
   ],
 };
 
-let commandsPaceCaretStyle = {
+export let commandsPaceCaretStyle = {
   title: "Change pace caret style...",
   configKey: "paceCaretStyle",
   list: [
@@ -1235,7 +1235,7 @@ let commandsPaceCaretStyle = {
   ],
 };
 
-let commandsRepeatedPace = {
+export let commandsRepeatedPace = {
   title: "Repeated pace...",
   configKey: "repeatedPace",
   list: [
@@ -1258,7 +1258,7 @@ let commandsRepeatedPace = {
   ],
 };
 
-let commandsPaceCaret = {
+export let commandsPaceCaret = {
   title: "Pace caret mode...",
   configKey: "paceCaret",
   list: [
@@ -1303,7 +1303,7 @@ let commandsPaceCaret = {
   ],
 };
 
-let commandsMinWpm = {
+export let commandsMinWpm = {
   title: "Change min wpm mode...",
   configKey: "minWpm",
   list: [
@@ -1328,7 +1328,7 @@ let commandsMinWpm = {
   ],
 };
 
-let commandsMinAcc = {
+export let commandsMinAcc = {
   title: "Change min accuracy mode...",
   configKey: "minAcc",
   list: [
@@ -1353,7 +1353,7 @@ let commandsMinAcc = {
   ],
 };
 
-let commandsMinBurst = {
+export let commandsMinBurst = {
   title: "Change min burst mode...",
   configKey: "minBurst",
   list: [
@@ -1388,7 +1388,7 @@ let commandsMinBurst = {
   ],
 };
 
-let commandsKeymapStyle = {
+export let commandsKeymapStyle = {
   title: "Keymap style...",
   configKey: "keymapStyle",
   list: [
@@ -1427,7 +1427,7 @@ let commandsKeymapStyle = {
   ],
 };
 
-let commandsKeymapLegendStyle = {
+export let commandsKeymapLegendStyle = {
   title: "Keymap legend style...",
   configKey: "keymapLegendStyle",
   list: [
@@ -1458,7 +1458,7 @@ let commandsKeymapLegendStyle = {
   ],
 };
 
-let commandsBritishEnglish = {
+export let commandsBritishEnglish = {
   title: "British english...",
   configKey: "britishEnglish",
   list: [
@@ -1483,7 +1483,7 @@ let commandsBritishEnglish = {
   ],
 };
 
-let commandsHighlightMode = {
+export let commandsHighlightMode = {
   title: "Highlight mode...",
   configKey: "highlightMode",
   list: [
@@ -1514,7 +1514,7 @@ let commandsHighlightMode = {
   ],
 };
 
-let commandsTimerStyle = {
+export let commandsTimerStyle = {
   title: "Timer/progress style...",
   configKey: "timerStyle",
   list: [
@@ -1545,7 +1545,7 @@ let commandsTimerStyle = {
   ],
 };
 
-let commandsTimerColor = {
+export let commandsTimerColor = {
   title: "Timer/progress color...",
   configKey: "timerColor",
   list: [
@@ -1584,7 +1584,7 @@ let commandsTimerColor = {
   ],
 };
 
-let commandsSingleListCommandLine = {
+export let commandsSingleListCommandLine = {
   title: "Single list command line...",
   configKey: "singleListCommandLine",
   list: [
@@ -1607,7 +1607,7 @@ let commandsSingleListCommandLine = {
   ],
 };
 
-let commandsTimerOpacity = {
+export let commandsTimerOpacity = {
   title: "Timer/progress opacity...",
   configKey: "timerOpacity",
   list: [
@@ -1646,7 +1646,7 @@ let commandsTimerOpacity = {
   ],
 };
 
-let commandsWordCount = {
+export let commandsWordCount = {
   title: "Change word count...",
   configKey: "words",
   list: [
@@ -1713,7 +1713,7 @@ let commandsWordCount = {
   ],
 };
 
-let commandsQuoteLengthConfig = {
+export let commandsQuoteLengthConfig = {
   title: "Change quote length...",
   configKey: "quoteLength",
   list: [
@@ -1774,7 +1774,7 @@ let commandsQuoteLengthConfig = {
   ],
 };
 
-let commandsPunctuation = {
+export let commandsPunctuation = {
   title: "Change punctuation...",
   configKey: "punctuation",
   list: [
@@ -1799,7 +1799,7 @@ let commandsPunctuation = {
   ],
 };
 
-let commandsNumbers = {
+export let commandsNumbers = {
   title: "Numbers...",
   configKey: "numbers",
   list: [
@@ -1824,7 +1824,7 @@ let commandsNumbers = {
   ],
 };
 
-let commandsSmoothCaret = {
+export let commandsSmoothCaret = {
   title: "Smooth caret...",
   configKey: "smoothCaret",
   list: [
@@ -1847,7 +1847,7 @@ let commandsSmoothCaret = {
   ],
 };
 
-let commandsQuickTab = {
+export let commandsQuickTab = {
   title: "Quick tab...",
   configKey: "quickTab",
   list: [
@@ -1870,7 +1870,7 @@ let commandsQuickTab = {
   ],
 };
 
-let commandsMode = {
+export let commandsMode = {
   title: "Change mode...",
   configKey: "mode",
   list: [
@@ -1923,7 +1923,7 @@ let commandsMode = {
   ],
 };
 
-let commandsTimeConfig = {
+export let commandsTimeConfig = {
   title: "Change time config...",
   configKey: "time",
   list: [
@@ -1980,7 +1980,7 @@ let commandsTimeConfig = {
   ],
 };
 
-let commandsConfidenceMode = {
+export let commandsConfidenceMode = {
   title: "Confidence mode...",
   configKey: "confidenceMode",
   list: [
@@ -2011,7 +2011,7 @@ let commandsConfidenceMode = {
   ],
 };
 
-let commandsStopOnError = {
+export let commandsStopOnError = {
   title: "Stop on error...",
   configKey: "stopOnError",
   list: [
@@ -2042,7 +2042,7 @@ let commandsStopOnError = {
   ],
 };
 
-let commandsFontSize = {
+export let commandsFontSize = {
   title: "Font size...",
   configKey: "fontSize",
   list: [
@@ -2103,7 +2103,7 @@ let commandsFontSize = {
   ],
 };
 
-let commandsPageWidth = {
+export let commandsPageWidth = {
   title: "Page width...",
   configKey: "pageWidth",
   list: [
@@ -2150,7 +2150,7 @@ let commandsPageWidth = {
   ],
 };
 
-let commandsPractiseWords = {
+export let commandsPractiseWords = {
   title: "Practice words...",
   list: [
     {
@@ -2257,7 +2257,7 @@ export function updateThemeCommands() {
   }
 }
 
-let commandsCopyWordsToClipboard = {
+export let commandsCopyWordsToClipboard = {
   title: "Are you sure...",
   list: [
     {
@@ -2284,7 +2284,7 @@ let commandsCopyWordsToClipboard = {
   ],
 };
 
-let commandsMonkeyPowerLevel = {
+export let commandsMonkeyPowerLevel = {
   title: "Power mode...",
   configKey: "monkeyPowerLevel",
   list: [

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -122,7 +122,7 @@ let defaultConfig = {
   oppositeShiftMode: "off",
   customBackground: "",
   customBackgroundSize: "cover",
-  customBackgroundFilter: [0, 1, 1, 1, 1],
+  customBackgroundFilter: [0, 1, 1, 1],
   customLayoutfluid: "qwerty#dvorak#colemak",
   monkeyPowerLevel: "off",
   minBurst: "off",

--- a/src/js/ready.js
+++ b/src/js/ready.js
@@ -5,6 +5,7 @@ import * as VerificationController from "./verification-controller";
 import * as Settings from "./settings";
 import * as RouteController from "./route-controller";
 import * as UI from "./ui";
+import * as URLParser from "./url";
 import * as SignOutButton from "./sign-out-button";
 import * as MonkeyPower from "./monkey-power";
 import * as NewVersionNotification from "./new-version-notification";
@@ -12,6 +13,7 @@ import * as NewVersionNotification from "./new-version-notification";
 ManualRestart.set();
 Misc.migrateFromCookies();
 UpdateConfig.loadFromLocalStorage();
+URLParser.loadFromUrl();
 Misc.getReleasesFromGitHub().then((v) => {
   NewVersionNotification.show(v[0].name);
 });

--- a/src/js/url.js
+++ b/src/js/url.js
@@ -288,13 +288,10 @@ export function loadFromUrl() {
 
   window.history.replaceState(null, null, url); // update the URL with new params
   // ui.js:129 prevents params from being shown for longer time
-  console.log(url);
 
   let appliedSettings = 0;
   // Search for and apply settings
   Object.keys(Settings).forEach((name) => {
-    console.log(name);
-    console.log(Settings[name].options);
     let val = url.searchParams.get(name.toLowerCase()); // value of parameter
     if (val !== null) {
       let res = Settings[name].set(val);

--- a/src/js/url.js
+++ b/src/js/url.js
@@ -2,7 +2,7 @@ import * as UpdateConfig from "./config";
 import * as Notifications from "./notifications";
 import * as Commands from "./commandline-lists";
 import * as CustomText from "./custom-text";
-import * as Settings from "./settings";
+import * as GlobalSettings from "./settings";
 
 // === Setting classes ===
 // the callback is used in `set()` method to set value in config
@@ -161,7 +161,8 @@ class CustomBackgroundFilterSetting {
     let converted = []; // values converted from string to float
     arr.forEach((num, i) => {
       let parsed = parseFloat(num);
-      if (this.validate(parsed) && this.check(parsed)) converted.push(parsed);
+      if (this.validate(parsed, i) && this.check(parsed, i))
+        converted.push(parsed);
       else return false;
     });
     this.callback(converted);
@@ -249,7 +250,7 @@ let Settings = {
     if (val.lenght === 9) {
       UpdateConfig.setCustomThemeColors(val);
       UpdateConfig.setCustomTheme(true);
-      Settings.setCustomThemeInputs();
+      GlobalSettings.setCustomThemeInputs();
     }
   }),
   randomTheme: new OptionsSetting(

--- a/src/js/url.js
+++ b/src/js/url.js
@@ -17,19 +17,18 @@ class OptionsSetting {
     this.callback = callback;
     this.options = {};
     if (byDisplay) {
-      command.list.forEach(
-        (option) =>
-          (this.options[option.display.toLowerCase()] = option.configValue)
-      );
+      command.list.forEach((option) => {
+        this.options[option.display.toLowerCase()] = option.configValue;
+      });
     } else {
       if (Array.isArray(command))
-        command.forEach(
-          (option) => (this.options[option.configValue] = option.configValue)
-        );
+        command.forEach((option) => {
+          this.options[option] = option;
+        });
       else
-        command.list.forEach(
-          (option) => (this.options[option.configValue] = option.configValue)
-        );
+        command.list.forEach((option) => {
+          this.options[option.configValue] = option.configValue;
+        });
     }
   }
 
@@ -43,7 +42,7 @@ class OptionsSetting {
   }
 
   validate(val) {
-    return this.options.keys().includes(val.toLowerCase());
+    return Object.keys(this.options).includes(val.toLowerCase());
   }
 }
 

--- a/src/js/url.js
+++ b/src/js/url.js
@@ -261,13 +261,6 @@ let Settings = {
   ),
 };
 
-export function loadFromUrl() {
-  Misc.getLanguageList().then((data) => {
-    (Settings.language = new OptionsSetting(UpdateConfig.setLanguage, data)),
-      applySettings(); // Needs to be called here to apply settings after language options are loaded
-  });
-}
-
 function applySettings() {
   let url = new URL(window.location.href);
 
@@ -313,4 +306,11 @@ function applySettings() {
       "Settings from URL"
     );
   }
+}
+
+export function loadFromUrl() {
+  Misc.getLanguageList().then((data) => {
+    (Settings.language = new OptionsSetting(UpdateConfig.setLanguage, data)),
+      applySettings(); // Needs to be called here to apply settings after language options are loaded
+  });
 }

--- a/src/js/url.js
+++ b/src/js/url.js
@@ -1,0 +1,323 @@
+import * as UpdateConfig from "./config";
+import * as Notifications from "./notifications";
+import * as Commands from "./commandline-lists";
+import * as CustomText from "./custom-text";
+import * as Settings from "./settings";
+
+// === Setting classes ===
+// the callback is used in `set()` method to set value in config
+// to set a value use the `set()` method
+// if input is valid `set()` method will call callback and return true, otherwise it will retrun false
+
+// Setting with multiple text options
+// allows only one option as input
+// `command` is used to get setting options
+class OptionsSetting {
+  constructor(callback, command, byDisplay = false) {
+    this.callback = callback;
+    this.options = {};
+    if (byDisplay) {
+      command.list.forEach(
+        (option) =>
+          (this.options[option.display.toLowerCase()] = option.configValue)
+      );
+    } else {
+      if (Array.isArray(command))
+        command.forEach(
+          (option) => (this.options[option.configValue] = option.configValue)
+        );
+      else
+        command.list.forEach(
+          (option) => (this.options[option.configValue] = option.configValue)
+        ); // migth be better to take option.display as input and convert it to option.configValue for some settings
+    }
+  }
+
+  set(val) {
+    val = val.toLowerCase(); // This might cause problems with settings that don't have lower-case config values - should revisit this later
+    if (this.validate(val)) {
+      this.callback(val);
+      return true;
+    }
+    return false;
+  }
+
+  validate(val) {
+    return this.options.keys().includes(val.toLowerCase());
+  }
+}
+
+class NumberSetting {
+  constructor(callback, min = undefined, max = undefined) {
+    this.callback = callback;
+    this.min = min;
+    this.max = max;
+  }
+
+  set(val) {
+    let num = parseInt(val);
+    if (this.validate(num) && this.check(num)) {
+      this.callback(num);
+      return true;
+    }
+    return false;
+  }
+
+  check(num) {
+    return (
+      (this.min < num || this.min === undefined) &&
+      (this.max > num || this.max === undefined)
+    );
+  }
+
+  validate(num) {
+    return !Number.isNaN(num);
+  }
+}
+
+class BoolSetting {
+  constructor(callback) {
+    this.callback = callback;
+    this.options = ["true", "on", "", "false", "off"];
+  }
+
+  set(val) {
+    val = val.toLowerCase();
+    if (val === "true" || val === "on" || val === "") {
+      this.callback(true);
+      return true;
+    } else if (val === "false" || val === "off") {
+      this.callback(false);
+      return true;
+    }
+    return false;
+  }
+}
+
+class TextSetting {
+  constructor(callback) {
+    this.callback = callback;
+  }
+
+  set(val) {
+    this.callback(val);
+    return true;
+  }
+}
+
+class OffOrNumberSetting {
+  constructor(callback1, callback2, min = undefined, max = undefined) {
+    this.callback1 = callback1;
+    this.callback2 = callback2;
+    this.min = min;
+    this.max = max;
+  }
+
+  set(val) {
+    if (["off", "false"].includes(val)) {
+      this.callback1(val);
+      return true;
+    }
+    let num = parseInt(val);
+    if (this.validate(num) && this.check(num)) {
+      this.callback1("custom");
+      this.callback2(num);
+      return true;
+    }
+    return false;
+  }
+
+  check(num) {
+    return (
+      (this.min < num || this.min === undefined) &&
+      (this.max > num || this.max === undefined)
+    );
+  }
+
+  validate(num) {
+    return !Number.isNaN(num);
+  }
+}
+
+class CustomBackgroundFilterSetting {
+  constructor(callback, sep = ",") {
+    this.callback = callback;
+    this.sep = sep;
+    // min,max values for each of the settings
+    // order is important!
+    this.values = {
+      0: [0.0, 5.0], // Blur
+      1: [0.0, 2.0], // Brightness
+      2: [0.0, 2.0], // Saturation
+      3: [0.0, 1.0], // Opacity
+    };
+  }
+
+  set(val) {
+    let arr = val.split(this.sep);
+    if (arr.lenght !== this.values.lenght)
+      // input array is incomplete
+      return false;
+
+    let converted = []; // values converted from string to float
+    arr.forEach((num, i) => {
+      let parsed = parseFloat(num);
+      if (this.validate(parsed) && this.check(parsed)) converted.push(parsed);
+      else return false;
+    });
+    this.callback(converted);
+    return true;
+  }
+
+  check(num, i) {
+    return this.values[i][0] < num < this.values[i][1];
+  }
+
+  validate(num) {
+    return !Number.isNaN(num);
+  }
+}
+
+// List of all settings that a user should be able to set from URL
+// might be interesting to add aliases
+// settings that don't work yet: quoteLength, theme, customTheme, tags
+let Settings = {
+  punctuation: new BoolSetting(UpdateConfig.setPunctuation),
+  mode: new OptionsSetting(UpdateConfig.setMode, Commands.commandsMode),
+  time: new NumberSetting(UpdateConfig.setTimeConfig),
+  words: new NumberSetting(UpdateConfig.setWordCount),
+  numbers: new BoolSetting(UpdateConfig.setNumbers),
+  quoteLength: new OptionsSetting(
+    UpdateConfig.setQuoteLength,
+    Commands.commandsQuoteLengthConfig,
+    true
+  ),
+  confidenceMode: new OptionsSetting(
+    UpdateConfig.setConfidenceMode,
+    Commands.commandsConfidenceMode
+  ),
+  stopOnError: new OptionsSetting(
+    UpdateConfig.setStopOnError,
+    Commands.commandsStopOnError
+  ),
+  repeateQuote: new OptionsSetting(
+    UpdateConfig.setRepeatQuotes,
+    Commands.commandsRepeatQuotes
+  ),
+  freedomMode: new BoolSetting(UpdateConfig.setFreedomMode),
+  strictSpace: new BoolSetting(UpdateConfig.setStrictSpace),
+  blindMode: new BoolSetting(UpdateConfig.setBlindMode),
+  singleListCommandLine: new OptionsSetting(
+    UpdateConfig.setSingleListCommandLine,
+    Commands.commandsSingleListCommandLine
+  ),
+  minWpm: new OffOrNumberSetting(
+    UpdateConfig.setMinWpm,
+    UpdateConfig.setMinWpmCustomSpeed
+  ),
+  minAcc: new OffOrNumberSetting(
+    UpdateConfig.setMinAcc,
+    UpdateConfig.setMinAccCustom
+  ),
+  minBurst: new OffOrNumberSetting(
+    UpdateConfig.setMinBurst,
+    UpdateConfig.setMinBurstCustomSpeed
+  ),
+  lazyMode: new BoolSetting(UpdateConfig.setLazyMode),
+  highlightMode: new OptionsSetting(
+    UpdateConfig.setHighlightMode,
+    Commands.commandsHighlightMode
+  ),
+  language: new OptionsSetting(
+    UpdateConfig.setLanguage,
+    Commands.commandsLanguages
+  ),
+  funbox: new OptionsSetting(UpdateConfig.setFunbox, Commands.commandsFunbox),
+  layout: new OptionsSetting(UpdateConfig.setLayout, Commands.commandsLayouts),
+  custom: new TextSetting(function (val) {
+    val = val.split("|");
+    CustomText.setText(val);
+    CustomText.setWord(val.length);
+  }),
+  // maybe merge theme and customTheme into one?
+  theme: new OptionsSetting(function (theme) {
+    UpdateConfig.setTheme(theme);
+    UpdateConfig.setCustomTheme(false);
+  }, Commands.themeCommands),
+  // possibly create custom setting to return validation status
+  customTheme: new TextSetting(function (val) {
+    val = val.split(",");
+    if (val.lenght === 9) {
+      UpdateConfig.setCustomThemeColors(val);
+      UpdateConfig.setCustomTheme(true);
+      Settings.setCustomThemeInputs();
+    }
+  }),
+  randomTheme: new OptionsSetting(
+    UpdateConfig.setRandomTheme,
+    Commands.commandsRandomTheme
+  ),
+  difficulty: new OptionsSetting(UpdateConfig.setDifficulty, [
+    "normal",
+    "expert",
+    "master",
+  ]),
+  customBackground: new TextSetting(UpdateConfig.setCustomBackground, null),
+  customBackgroundFilter: new CustomBackgroundFilterSetting(
+    UpdateConfig.setCustomBackgroundFilter
+  ),
+  customBackgroundSize: new OptionsSetting(
+    UpdateConfig.setCustomBackgroundSize,
+    ["cover", "containt", "max"]
+  ),
+};
+
+export function loadFromUrl() {
+  let url = new URL(window.location.href);
+
+  // Parse URL params - set param keys to lower case
+  let splitSettings = decodeURI(url.search).split("&");
+  let availableSettings = splitSettings.length;
+  let urlSettings = [];
+  splitSettings.forEach((val) => {
+    let set = val.split("=");
+    set[0] = set[0].toLowerCase();
+    urlSettings.push(set.join("="));
+  });
+  url.search = urlSettings.join("&");
+
+  window.history.replaceState(null, null, url); // update the URL with new params
+  // ui.js:129 prevents params from being shown for longer time
+  console.log(url);
+
+  let appliedSettings = 0;
+  // Search for and apply settings
+  Object.keys(Settings).forEach((name) => {
+    console.log(name);
+    console.log(Settings[name].options);
+    let val = url.searchParams.get(name.toLowerCase()); // value of parameter
+    if (val !== null) {
+      let res = Settings[name].set(val);
+      if (res) appliedSettings += 1;
+      else
+        Notifications.add(
+          `Value for setting "${name}" is not valid`,
+          -1,
+          undefined,
+          "Settings from URL"
+        );
+    }
+  });
+
+  // Notify user about applied settings (if none, don't notify)
+  if (appliedSettings > 0) {
+    let quantity = "Some";
+    if (availableSettings === appliedSettings) quantity = "All";
+    Notifications.add(
+      `${quantity} settings applied`,
+      1,
+      undefined,
+      "Settings from URL"
+    );
+  }
+}

--- a/src/js/url.js
+++ b/src/js/url.js
@@ -29,7 +29,7 @@ class OptionsSetting {
       else
         command.list.forEach(
           (option) => (this.options[option.configValue] = option.configValue)
-        ); // migth be better to take option.display as input and convert it to option.configValue for some settings
+        );
     }
   }
 
@@ -155,9 +155,8 @@ class CustomBackgroundFilterSetting {
 
   set(val) {
     let arr = val.split(this.sep);
-    if (arr.lenght !== this.values.lenght)
-      // input array is incomplete
-      return false;
+    // input array is incomplete
+    if (arr.lenght !== this.values.lenght) return false;
 
     let converted = []; // values converted from string to float
     arr.forEach((num, i) => {

--- a/src/js/url.js
+++ b/src/js/url.js
@@ -238,11 +238,6 @@ let Settings = {
     CustomText.setText(val);
     CustomText.setWord(val.length);
   }),
-  // maybe merge theme and customTheme into one?
-  theme: new OptionsSetting(function (theme) {
-    UpdateConfig.setTheme(theme);
-    UpdateConfig.setCustomTheme(false);
-  }, Commands.themeCommands),
   // possibly create custom setting to return validation status
   customTheme: new TextSetting(function (val) {
     val = val.split(",");
@@ -252,10 +247,6 @@ let Settings = {
       GlobalSettings.setCustomThemeInputs();
     }
   }),
-  randomTheme: new OptionsSetting(
-    UpdateConfig.setRandomTheme,
-    Commands.commandsRandomTheme
-  ),
   difficulty: new OptionsSetting(UpdateConfig.setDifficulty, [
     "normal",
     "expert",

--- a/src/js/url.js
+++ b/src/js/url.js
@@ -3,6 +3,7 @@ import * as Notifications from "./notifications";
 import * as Commands from "./commandline-lists";
 import * as CustomText from "./custom-text";
 import * as GlobalSettings from "./settings";
+import * as Misc from "./misc";
 
 // === Setting classes ===
 // the callback is used in `set()` method to set value in config
@@ -227,10 +228,8 @@ let Settings = {
     UpdateConfig.setHighlightMode,
     Commands.commandsHighlightMode
   ),
-  language: new OptionsSetting(
-    UpdateConfig.setLanguage,
-    Commands.commandsLanguages
-  ),
+  // Moved to loadFromUrl() to wait for languages options to load
+  // language: new OptionsSetting(UpdateConfig.setLanguage, languages),
   funbox: new OptionsSetting(UpdateConfig.setFunbox, Commands.commandsFunbox),
   layout: new OptionsSetting(UpdateConfig.setLayout, Commands.commandsLayouts),
   custom: new TextSetting(function (val) {
@@ -263,6 +262,13 @@ let Settings = {
 };
 
 export function loadFromUrl() {
+  Misc.getLanguageList().then((data) => {
+    (Settings.language = new OptionsSetting(UpdateConfig.setLanguage, data)),
+      applySettings(); // Needs to be called here to apply settings after language options are loaded
+  });
+}
+
+function applySettings() {
   let url = new URL(window.location.href);
 
   // Parse URL params - set param keys to lower case


### PR DESCRIPTION
This PR builds from what was done in #1394 and also probably closes #1394.

You can add parameters to URL that if recognized will be applied to settings.

The `?` separates settings from the rest of the URL and `&` separates settings from each other. Each setting has key as its name followed by `=` and the desired value.
Example URL might look like this `https://monkeytype.com/?mode=words&words=25&difficulty=normal` or like this `/?mode=custom&custom=Hi|hi|hi!`.