### PR TITLE
Fix quote in german.json

### DIFF
--- a/static/quotes/german.json
+++ b/static/quotes/german.json
@@ -2384,9 +2384,9 @@
       "id": 397
     },
     {
-      "text": "Damit aus einem schlechten Tag ein miserabler wird, verbringe ich ihn damit, das Unmöglich zu wollen.",
+      "text": "Damit aus einem schlechten Tag ein miserabler wird, verbringe ich ihn damit, das Unmögliche zu wollen.",
       "source": "Calvin und Hobbes",
-      "length": 101,
+      "length": 102,
       "id": 398
     },
     {


### PR DESCRIPTION
This is a tiny fix for a German quote. 
das Unmöglich -> das Unmögliche

Source: (if you don't trust me 😄)
http://www.calvin-und-hobbes.com/zitate.html (number 21)

(my first pull request ever, yay \(^o^)/ )