### PR TITLE
Allow British English to replace capitalised words

### DIFF
--- a/src/js/test/british-english.js
+++ b/src/js/test/british-english.js
@@ -1,3 +1,5 @@
+import { capitalizeFirstLetter } from "./misc";
+
 let list = null;
 
 export async function getList() {
@@ -13,5 +15,12 @@ export async function getList() {
 
 export async function replace(word) {
   let list = await getList();
-  return list[list.findIndex((a) => a[0] === word)]?.[1];
+  var britishWord =
+    list[list.findIndex((a) => a[0] === word.toLowerCase())]?.[1];
+  if (typeof britishWord !== "undefined") {
+    if (word.charAt(0) === word.charAt(0).toUpperCase()) {
+      britishWord = capitalizeFirstLetter(britishWord);
+    }
+  }
+  return britishWord;
 }


### PR DESCRIPTION
### Description

Allows words that are not competely lowercase to be matched with the wordlist and replaced. Re-capitalises the replacement of a capitalised word. Not robust for words with capitalisation outside of the first letter.

Fixes cases such as "Honorable" in quote 1048.