### PR TITLE
Incement accuracy even for trailingComposeChars

### DIFF
--- a/src/js/input-controller.js
+++ b/src/js/input-controller.js
@@ -398,15 +398,15 @@ function handleChar(char, charIndex) {
     char +
     TestLogic.input.current.substring(charIndex + 1);
 
+  MonkeyPower.addPower(thisCharCorrect);
+  TestStats.incrementAccuracy(thisCharCorrect);
+
   if (!thisCharCorrect && Misc.trailingComposeChars.test(resultingWord)) {
     TestLogic.input.current = resultingWord;
     TestUI.updateWordElement();
     Caret.updatePosition();
     return;
   }
-
-  MonkeyPower.addPower(thisCharCorrect);
-  TestStats.incrementAccuracy(thisCharCorrect);
 
   if (!thisCharCorrect) {
     TestStats.incrementKeypressErrors();


### PR DESCRIPTION
Found the root cause for https://github.com/Miodec/monkeytype/issues/2057

Even though the bug is fixed with the change from Mio, typing \` will still keep the accuracy as 100 whereas a wrong character will drop it to 0. This fix will make sure \` will also be counted during calculating accuracy.