### PR TITLE
Introduce auto switching between light and dark theme

### DIFF
--- a/src/js/commandline-lists.js
+++ b/src/js/commandline-lists.js
@@ -664,6 +664,29 @@ let commandsFlipTestColors = {
   ],
 };
 
+let commandsAutoSwitchTheme = {
+  title: "Auto switch theme accroding to system",
+  configKey: "autoSwitchTheme",
+  list: [
+    {
+      id: "setAutoSwitchingOff",
+      display: "off",
+      configValue: false,
+      exec: () => {
+        UpdateConfig.setAutoSwitchTheme(false);
+      },
+    },
+    {
+      id: "setAutoSwitchingOn",
+      display: "on",
+      configValue: true,
+      exec: () => {
+        UpdateConfig.setAutoSwitchTheme(true);
+      },
+    },
+  ],
+};
+
 let commandsSmoothLineScroll = {
   title: "Smooth line scroll...",
   configKey: "smoothLineScroll",
@@ -2558,6 +2581,12 @@ export let defaultCommands = {
       display: "Flip test colors...",
       icon: "fa-adjust",
       subgroup: commandsFlipTestColors,
+    },
+    {
+      id: "changeAutoSwitchTheme",
+      display: "Toggle auto switching theme...",
+      icon: "fa-adjust",
+      subgroup: commandsAutoSwitchTheme,
     },
     {
       id: "changeSmoothLineScroll",

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -76,6 +76,7 @@ let defaultConfig = {
   caretStyle: "default",
   paceCaretStyle: "default",
   flipTestColors: false,
+  autoSwitchTheme: false,
   layout: "default",
   funbox: "none",
   confidenceMode: "off",
@@ -710,6 +711,11 @@ export function toggleFlipTestColors() {
   config.flipTestColors = !config.flipTestColors;
   TestUI.flipColors(config.flipTestColors);
   saveToLocalStorage();
+}
+
+export function setAutoSwitchTheme(val, nosave) {
+  config.autoSwitchTheme = val;
+  if (!nosave) saveToLocalStorage();
 }
 
 //extra color

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -41,6 +41,7 @@ let loadDone;
 
 let defaultConfig = {
   theme: "serika_dark",
+  themeLight: "serika",
   customTheme: false,
   customThemeColors: [
     "#323437",

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -1617,6 +1617,7 @@ export function apply(configObj) {
     }
   });
   if (configObj && configObj != null && configObj != "null") {
+    setAutoSwitchTheme(configObj.autoSwitchTheme, true);
     setTheme(configObj.theme, true);
     setCustomThemeColors(configObj.customThemeColors, true);
     setCustomTheme(configObj.customTheme, true, true);

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -143,6 +143,10 @@ async function initGroups() {
     "flipTestColors",
     UpdateConfig.setFlipTestColors
   );
+  groups.autoSwitchTheme = new SettingsGroup(
+    "autoSwitchTheme",
+    UpdateConfig.setAutoSwitchTheme
+  );
   groups.swapEscAndTab = new SettingsGroup(
     "swapEscAndTab",
     UpdateConfig.setSwapEscAndTab

--- a/src/js/theme-controller.js
+++ b/src/js/theme-controller.js
@@ -223,9 +223,11 @@ window
   .matchMedia("(prefers-color-scheme: dark)")
   .addEventListener("change", (e) => {
     let newColorTheme = e.matches ? "dark" : "light";
-    if (newColorTheme == "light") {
-      apply(Config.themeLight);
-    } else if (newColorTheme == "dark") {
-      apply(Config.theme);
+    if (Config.autoSwitchTheme) {
+      if (newColorTheme == "light") {
+        apply(Config.themeLight);
+      } else if (newColorTheme == "dark") {
+        apply(Config.theme);
+      }
     }
   });

--- a/src/js/theme-controller.js
+++ b/src/js/theme-controller.js
@@ -1,5 +1,6 @@
 import * as ThemeColors from "./theme-colors";
 import * as ChartController from "./chart-controller";
+import * as Notifications from "./notifications";
 import * as Misc from "./misc";
 import Config from "./config";
 import * as UI from "./ui";
@@ -226,8 +227,10 @@ window
     if (Config.autoSwitchTheme) {
       if (newColorTheme == "light") {
         apply(Config.themeLight);
+        Notifications.add("Switched to light mode", 0, 1000, null, null);
       } else if (newColorTheme == "dark") {
         apply(Config.theme);
+        Notifications.add("Switched to dark mode", 0, 1000, null, null);
       }
     }
   });

--- a/src/js/theme-controller.js
+++ b/src/js/theme-controller.js
@@ -218,3 +218,14 @@ export function applyCustomBackground() {
     applyCustomBackgroundSize();
   }
 }
+
+window
+  .matchMedia("(prefers-color-scheme: dark)")
+  .addEventListener("change", (e) => {
+    let newColorTheme = e.matches ? "dark" : "light";
+    if (newColorTheme == "light") {
+      apply(Config.themeLight);
+    } else if (newColorTheme == "dark") {
+      apply(Config.theme);
+    }
+  });

--- a/static/index.html
+++ b/static/index.html
@@ -3304,6 +3304,22 @@
                   </div>
                 </div>
               </div>
+              <div class="section autoSwitchTheme">
+                <h1>auto switch theme according to system</h1>
+                <div class="text">
+                  By default, this is not enabled. If enabled, the theme will
+                  auto switch according to system theme. This only works on
+                  Windows and Mac.
+                </div>
+                <div class="buttons">
+                  <div class="button off" tabindex="0" onclick="this.blur();">
+                    off
+                  </div>
+                  <div class="button on" tabindex="0" onclick="this.blur();">
+                    on
+                  </div>
+                </div>
+              </div>
               <div class="section colorfulMode">
                 <h1>colorful mode</h1>
                 <div class="text">


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

<!-- Please describe the change(s) made in your PR -->

Closes #1629

Introduces auto-switching between light and dark mode as per system theme and also provides button in settings to toggle this feature.

Video:

https://user-images.githubusercontent.com/24855641/142440340-9d5f3a21-63c5-42ae-ab3d-3b97d5c45ad9.mp4






<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/Miodec/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
