### PR TITLE
fixed length type for english quote

### DIFF
--- a/static/quotes/english.json
+++ b/static/quotes/english.json
@@ -32380,7 +32380,7 @@
     {
       "text": "Maybe you should just press the button.",
       "source": "The Maze Runner",
-      "length": "38",
+      "length": 38,
       "id": 5455
     },
     {


### PR DESCRIPTION
A quote had a different type for its `length` field than the other quotes. This broke a parser I was writing. 
