### PR TITLE
Improve British English replacement for edge cases

### DIFF
--- a/src/js/test/british-english.js
+++ b/src/js/test/british-english.js
@@ -20,13 +20,13 @@ export async function replace(word) {
   );
   return replacement
     ? word.replace(
-        RegExp(`^(?:([\\W]*)${replacement[0]}([\\W]*))$`, "gi"),
-        (_, $1, $2) =>
+        RegExp(`^(?:([\\W]*)(${replacement[0]})([\\W]*))$`, "gi"),
+        (_, $1, $2, $3) =>
           $1 +
-          (word.charAt(0) === word.charAt(0).toUpperCase()
+          ($2.charAt(0) === $2.charAt(0).toUpperCase()
             ? capitalizeFirstLetter(replacement[1])
             : replacement[1]) +
-          $2
+          $3
       )
     : word;
 }

--- a/src/js/test/british-english.js
+++ b/src/js/test/british-english.js
@@ -15,12 +15,18 @@ export async function getList() {
 
 export async function replace(word) {
   let list = await getList();
-  var britishWord =
-    list[list.findIndex((a) => a[0] === word.toLowerCase())]?.[1];
-  if (typeof britishWord !== "undefined") {
-    if (word.charAt(0) === word.charAt(0).toUpperCase()) {
-      britishWord = capitalizeFirstLetter(britishWord);
-    }
-  }
-  return britishWord;
+  let replacement = list.find((a) =>
+    word.match(RegExp(`([\\W\\D]*)${a[0]}([\\W\\D]*)`, "gi"))
+  );
+  return replacement
+    ? word.replace(
+        RegExp(`([\\W\\D]*)${replacement[0]}([\\W\\D]*)`, "gi"),
+        (_, $1, $2) =>
+          $1 +
+          (word.charAt(0) === word.charAt(0).toUpperCase()
+            ? capitalizeFirstLetter(replacement[1])
+            : replacement[1]) +
+          $2
+      )
+    : word;
 }

--- a/src/js/test/british-english.js
+++ b/src/js/test/british-english.js
@@ -16,11 +16,11 @@ export async function getList() {
 export async function replace(word) {
   let list = await getList();
   let replacement = list.find((a) =>
-    word.match(RegExp(`([\\W\\D]*)${a[0]}([\\W\\D]*)`, "gi"))
+    word.match(RegExp(`^([\\W]*${a[0]}[\\W]*)$`, "gi"))
   );
   return replacement
     ? word.replace(
-        RegExp(`([\\W\\D]*)${replacement[0]}([\\W\\D]*)`, "gi"),
+        RegExp(`^(?:([\\W]*)${replacement[0]}([\\W]*))$`, "gi"),
         (_, $1, $2) =>
           $1 +
           (word.charAt(0) === word.charAt(0).toUpperCase()

--- a/src/js/test/british-english.js
+++ b/src/js/test/british-english.js
@@ -24,7 +24,9 @@ export async function replace(word) {
         (_, $1, $2, $3) =>
           $1 +
           ($2.charAt(0) === $2.charAt(0).toUpperCase()
-            ? capitalizeFirstLetter(replacement[1])
+            ? $2 === $2.toUpperCase()
+              ? replacement[1].toUpperCase()
+              : capitalizeFirstLetter(replacement[1])
             : replacement[1]) +
           $3
       )


### PR DESCRIPTION
### Description

* Allows words that include punctuation to be matched with the wordlist and replaced. Original punctuation is retained. Fixes cases such as "`gray,`" in quote 1953.
* Fully recapitalises the replacement of entirely uppercase words.