### PR TITLE
Update code_css.json

### DIFF
--- a/static/languages/code_css.json
+++ b/static/languages/code_css.json
@@ -16,7 +16,7 @@
     "height",
     "padding",
     "margin",
-    "soild",
+    "solid",
     "border",
     "display",
     "inline",


### PR DESCRIPTION
fix typo 'soild' to 'solid'

<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description
Fixes a typo.  There is no property in CSS 'soild', but the word 'solid' is a common border property.
<!-- Please describe the change(s) made in your PR -->

Closes #

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/Miodec/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
