### PR TITLE
Removes trailing spaces and unicode quotation characters from english.json

### DIFF
--- a/static/quotes/english.json
+++ b/static/quotes/english.json
@@ -32372,7 +32372,7 @@
       "id": 5449
     },
     {
-      "text": "If you ain’t scared... you ain’t human.",
+      "text": "If you ain't scared... you ain't human.",
       "source": "Alby, The Maze Runner",
       "length": 37,
       "id": 5451
@@ -32450,7 +32450,7 @@
       "id": 5464
     },
     {
-      "text": "My friend Kira always said that life is like an extremely difficult, horribly unbalanced video game. When you’re born, you’re given a randomly generated character, with a randomly determined name, race, face, and social class. Your body is your avatar, and you spawn in a random geographic location, at a random moment in human history, surrounded by a random group of people, and then you have to try to survive for as long as you can. Sometimes the game might seem easy. Even fun. Other times it might be so difficult you want to give up and quit. But unfortunately, in this game you only get one life. When your body grows too hungry or thirsty or ill or injured or old, your health meter runs out and then it’s Game Over. Some people play the game for a hundred years without ever figuring out that it’s a game, or that there is a way to win it. To win the videogame of life you just have to try to make the experience of being forced to play it as pleasant as possible, for yourself, and for all of the other players you encounter in your travels. Kira says that if everyone played the game to win, it’d be a lot more fun for everyone.",
+      "text": "My friend Kira always said that life is like an extremely difficult, horribly unbalanced video game. When you're born, you're given a randomly generated character, with a randomly determined name, race, face, and social class. Your body is your avatar, and you spawn in a random geographic location, at a random moment in human history, surrounded by a random group of people, and then you have to try to survive for as long as you can. Sometimes the game might seem easy. Even fun. Other times it might be so difficult you want to give up and quit. But unfortunately, in this game you only get one life. When your body grows too hungry or thirsty or ill or injured or old, your health meter runs out and then it's Game Over. Some people play the game for a hundred years without ever figuring out that it's a game, or that there is a way to win it. To win the videogame of life you just have to try to make the experience of being forced to play it as pleasant as possible, for yourself, and for all of the other players you encounter in your travels. Kira says that if everyone played the game to win, it'd be a lot more fun for everyone.",
       "source": "Anorak's Almanac, Ready Player Two",
       "length": 1139,
       "id": 5465
@@ -32474,7 +32474,7 @@
       "id": 5468
     },
     {
-      "text": "The world’s population was fast approaching ten billion people, and Mother Earth was making it abundantly clear that she could no longer sustain all of us.",
+      "text": "The world's population was fast approaching ten billion people, and Mother Earth was making it abundantly clear that she could no longer sustain all of us.",
       "source": "Wade Watts, Ready Player Two",
       "length": 154,
       "id": 5469
@@ -32556,7 +32556,7 @@
       "id": 5483
     },
     {
-      "text": "Have you ever watched the jet cars race on the boulevard?...I sometimes think drivers don’t know what grass is, or flowers, because they never see them slowly...If you showed a driver a green blur, Oh yes! He'd say, that’s grass! A pink blur! That’s a rose garden! White blurs are houses. Brown blurs are cows.",
+      "text": "Have you ever watched the jet cars race on the boulevard?...I sometimes think drivers don't know what grass is, or flowers, because they never see them slowly...If you showed a driver a green blur, Oh yes! He'd say, that's grass! A pink blur! That's a rose garden! White blurs are houses. Brown blurs are cows.",
       "source": "Fahrenheit 451",
       "length": 310,
       "id": 5484
@@ -32934,7 +32934,7 @@
       "id": 5546
     },
     {
-      "text": "You don’t want to go for realism, you can go for better than realism. What do you mean better than realism? How about an elephant with blue eyes.",
+      "text": "You don't want to go for realism, you can go for better than realism. What do you mean better than realism? How about an elephant with blue eyes.",
       "source": "Terry A. Devis",
       "length": 145,
       "id": 5547
@@ -33180,7 +33180,7 @@
       "id": 5599
     },
     {
-      "text": "Only once in your life, I truly believe, you find someone who can completely turn your world around. You tell them things that you’ve never shared with another soul and they absorb everything you say and actually want to hear more. You share hopes for the future, dreams that will never come true, goals that were never achieved and the many disappointments life has thrown at you. When something wonderful happens, you can’t wait to tell them about it, knowing they will share in your excitement. They are not embarrassed to cry with you when you are hurting or laugh with you when you make a fool of yourself. Never do they hurt your feelings or make you feel like you are not good enough, but rather they build you up and show you the things about yourself that make you special and even beautiful. There is never any pressure, jealousy or competition but only a quiet calmness when they are around. You can be yourself and not worry about what they will think of you because they love you for who you are. The things that seem insignificant to most people such as a note, song or walk become invaluable treasures kept safe in your heart to cherish forever. Memories of your childhood come back and are so clear and vivid it’s like being young again. Colours seem brighter and more brilliant. Laughter seems part of daily life where before it was infrequent or didn’t exist at all. A phone call or two during the day helps to get you through a long day’s work and always brings a smile to your face. In their presence, there’s no need for continuous conversation, but you find you’re quite content in just having them nearby. Things that never interested you before become fascinating because you know they are important to this person who is so special to you. You think of this person on every occasion and in everything you do. Simple things bring them to mind like a pale blue sky, gentle wind or even a storm cloud on the horizon. You open your heart knowing that there’s a chance it may be broken one day and in opening your heart, you experience a love and joy that you never dreamed possible. You find that being vulnerable is the only way to allow your heart to feel true pleasure that’s so real it scares you. You find strength in knowing you have a true friend and possibly a soul mate who will remain loyal to the end. Life seems completely different, exciting and worthwhile. Your only hope and security is in knowing that they are a part of your life.",
+      "text": "Only once in your life, I truly believe, you find someone who can completely turn your world around. You tell them things that you've never shared with another soul and they absorb everything you say and actually want to hear more. You share hopes for the future, dreams that will never come true, goals that were never achieved and the many disappointments life has thrown at you. When something wonderful happens, you can't wait to tell them about it, knowing they will share in your excitement. They are not embarrassed to cry with you when you are hurting or laugh with you when you make a fool of yourself. Never do they hurt your feelings or make you feel like you are not good enough, but rather they build you up and show you the things about yourself that make you special and even beautiful. There is never any pressure, jealousy or competition but only a quiet calmness when they are around. You can be yourself and not worry about what they will think of you because they love you for who you are. The things that seem insignificant to most people such as a note, song or walk become invaluable treasures kept safe in your heart to cherish forever. Memories of your childhood come back and are so clear and vivid it's like being young again. Colours seem brighter and more brilliant. Laughter seems part of daily life where before it was infrequent or didn't exist at all. A phone call or two during the day helps to get you through a long day's work and always brings a smile to your face. In their presence, there's no need for continuous conversation, but you find you're quite content in just having them nearby. Things that never interested you before become fascinating because you know they are important to this person who is so special to you. You think of this person on every occasion and in everything you do. Simple things bring them to mind like a pale blue sky, gentle wind or even a storm cloud on the horizon. You open your heart knowing that there's a chance it may be broken one day and in opening your heart, you experience a love and joy that you never dreamed possible. You find that being vulnerable is the only way to allow your heart to feel true pleasure that's so real it scares you. You find strength in knowing you have a true friend and possibly a soul mate who will remain loyal to the end. Life seems completely different, exciting and worthwhile. Your only hope and security is in knowing that they are a part of your life.",
       "source": "Bob Marley",
       "length": 2468,
       "id": 5600
@@ -33720,7 +33720,7 @@
       "id": 5690
     },
     {
-      "text": "I guess I’m a little weird. I like to talk to trees and animals. That’s okay though; I have more fun than most people.",
+      "text": "I guess I'm a little weird. I like to talk to trees and animals. That's okay though; I have more fun than most people.",
       "source": "Bob Ross",
       "length": 118,
       "id": 5691
@@ -33750,7 +33750,7 @@
       "id": 5695
     },
     {
-      "text": "This is your world\nYou’re the creator\nFind freedom on this canvas\nBelieve, that you can do it,\n'Cuz you can do it.\nYou can do it.",
+      "text": "This is your world\nYou're the creator\nFind freedom on this canvas\nBelieve, that you can do it,\n'Cuz you can do it.\nYou can do it.",
       "source": "Bob Ross",
       "length": 125,
       "id": 5696
@@ -33810,9 +33810,9 @@
       "id": 5705
     },
     {
-      "text": "The only thing that we're allowed to believe is that we won't regret the choice we made. ",
+      "text": "The only thing that we're allowed to believe is that we won't regret the choice we made.",
       "source": "Hajime Isayama, Attack on Titan",
-      "length": 89,
+      "length": 88,
       "id": 5706
     },
     {
@@ -33864,13 +33864,13 @@
       "id": 5714
     },
     {
-      "text": "If we waited until we were ready, we would be waiting our entire lives. ",
+      "text": "If we waited until we were ready, we would be waiting our entire lives.",
       "source": "Violet and Klaus Baudelaire, A Series of Unfortunate Events by Lemony Snicket",
-      "length": 72,
+      "length": 71,
       "id": 5715
     },
     {
-      "text": "Christie! Ms. Esposito! Hold up. Hey, Jimmy McGill, we met inside. Hi. You didn’t get it. You were never gonna get it. They dangle these things in front of you. They tell you, you got a chance, but I’m sorry. It’s a lie because they had already made up their mind and they knew what they were going to do before you walked in the door. You made a mistake and they are never forgetting it. As far as they’re concerned, your mistake is just, it’s who you are. And it’s all you are. And I’m not just talking about the scholarship here, I’m talking about everything. I mean, they’ll smile at you, they’ll pat you on the head, but they are never, ever letting you in. But listen… Listen… it doesn’t matter. It doesn’t because you don’t need them. They’re not going to give it to you? So what? You’re going to take it. You’re going to do whatever it takes. Do you hear me? You are not going to play by the rules. You’re going to go your own way. You’re going to do what they won’t do. You’re going to be smart. You are going to cut corners and you are going to win. Their on the 35th floor? You’re going to be on the 50th floor. You’re going to be looking down on them. And the higher you rise, the more they’re going to hate you. Good. Good! You rub their noses in it. You make them suffer. Because you don’t matter all that much to them. So what? So what? Screw them! Remember... the winner takes it all. You understand what I’m trying to tell you, right? All right. All right. Go get them.",
+      "text": "Christie! Ms. Esposito! Hold up. Hey, Jimmy McGill, we met inside. Hi. You didn't get it. You were never gonna get it. They dangle these things in front of you. They tell you, you got a chance, but I'm sorry. It's a lie because they had already made up their mind and they knew what they were going to do before you walked in the door. You made a mistake and they are never forgetting it. As far as they're concerned, your mistake is just, it's who you are. And it's all you are. And I'm not just talking about the scholarship here, I'm talking about everything. I mean, they'll smile at you, they'll pat you on the head, but they are never, ever letting you in. But listen... Listen... it doesn't matter. It doesn't because you don't need them. They're not going to give it to you? So what? You're going to take it. You're going to do whatever it takes. Do you hear me? You are not going to play by the rules. You're going to go your own way. You're going to do what they won't do. You're going to be smart. You are going to cut corners and you are going to win. Their on the 35th floor? You're going to be on the 50th floor. You're going to be looking down on them. And the higher you rise, the more they're going to hate you. Good. Good! You rub their noses in it. You make them suffer. Because you don't matter all that much to them. So what? So what? Screw them! Remember... the winner takes it all. You understand what I'm trying to tell you, right? All right. All right. Go get them.",
       "source": "Better Call Saul",
       "length": 1486,
       "id": 5716
@@ -33882,7 +33882,7 @@
       "id": 5717
     },
     {
-      "text": "Did you ever hear the tragedy of Darth Plagueis The Wise? I thought not. It’s not a story the Jedi would tell you. It’s a Sith legend. Darth Plagueis was a Dark Lord of the Sith, so powerful and so wise he could use the Force to influence the midichlorians to create life… He had such a knowledge of the dark side that he could even keep the ones he cared about from dying. The dark side of the Force is a pathway to many abilities some consider to be unnatural. He became so powerful… the only thing he was afraid of was losing his power, which eventually, of course, he did. Unfortunately, he taught his apprentice everything he knew, then his apprentice killed him in his sleep. Ironic. He could save others from death, but not himself.",
+      "text": "Did you ever hear the tragedy of Darth Plagueis The Wise? I thought not. It's not a story the Jedi would tell you. It's a Sith legend. Darth Plagueis was a Dark Lord of the Sith, so powerful and so wise he could use the Force to influence the midichlorians to create life... He had such a knowledge of the dark side that he could even keep the ones he cared about from dying. The dark side of the Force is a pathway to many abilities some consider to be unnatural. He became so powerful... the only thing he was afraid of was losing his power, which eventually, of course, he did. Unfortunately, he taught his apprentice everything he knew, then his apprentice killed him in his sleep. Ironic. He could save others from death, but not himself.",
       "source": "Star Wars: Revenge of the Sith (Episode III)",
       "length": 739,
       "id": 5718
@@ -33924,9 +33924,9 @@
       "id": 5724
     },
     {
-      "text": "Oh, you like to think you're a god. You're not a god, you're just a parasite, eaten out with jealousy and envy and longing for the lives of others. You feed on them, on the memory of love and loss and birth and death and joy and sorrow! Come on, then. Take mine. Take my memories. ",
+      "text": "Oh, you like to think you're a god. You're not a god, you're just a parasite, eaten out with jealousy and envy and longing for the lives of others. You feed on them, on the memory of love and loss and birth and death and joy and sorrow! Come on, then. Take mine. Take my memories.",
       "source": "Doctor Who",
-      "length": 292,
+      "length": 280,
       "id": 5725
     },
     {
@@ -33966,27 +33966,27 @@
       "id": 5731
     },
     {
-      "text": "Once you’ve met someone, you never really forget them. It just takes a while for your memories to return.",
+      "text": "Once you've met someone, you never really forget them. It just takes a while for your memories to return.",
       "source": "Spirited Away",
       "length": 104,
       "id": 5732
     },
     {
-      "text": "Hypertext Transfer Protocol Secure (HTTPS) is an extension of the Hypertext Transfer Protocol (HTTP). It is used for secure communication over a computer network, and is widely used on the Internet. In HTTPS, the communication protocol is encrypted using Transport Layer Security (TLS) or, formerly, Secure Sockets Layer (SSL). The protocol is therefore also referred to as HTTP over TLS, or HTTP over SSL. ",
+      "text": "Hypertext Transfer Protocol Secure (HTTPS) is an extension of the Hypertext Transfer Protocol (HTTP). It is used for secure communication over a computer network, and is widely used on the Internet. In HTTPS, the communication protocol is encrypted using Transport Layer Security (TLS) or, formerly, Secure Sockets Layer (SSL). The protocol is therefore also referred to as HTTP over TLS, or HTTP over SSL.",
       "source": "Wikipedia",
-      "length": 407,
+      "length": 406,
       "id": 5733
     },
     {
-      "text": "The Ultimate Typing Championship was created in order to promote typing and find the fastest typists in the United States of America. Players compete against each other in typing races. Typing races are done in real time online via an online typing race application. Finalists compete in person at SXSW in Austin, Texas. The Ultimate Typing Championship was initially created by the keyboard manufacturer Das Keyboard. ",
+      "text": "The Ultimate Typing Championship was created in order to promote typing and find the fastest typists in the United States of America. Players compete against each other in typing races. Typing races are done in real time online via an online typing race application. Finalists compete in person at SXSW in Austin, Texas. The Ultimate Typing Championship was initially created by the keyboard manufacturer Das Keyboard.",
       "source": "Wikipedia - Ultimate Typing Championship",
-      "length": 419,
+      "length": 418,
       "id": 5734
     },
     {
-      "text": "Colemak is a keyboard layout for Latin-script alphabets. The layout is designed to make typing more efficient and comfortable by placing the most frequently used letters of the English language on the home row. Created in 2006, it is named after its inventor, Shai Coleman. Most major modern operating systems such as Mac OS, Linux, Android, Chrome OS, and BSD support Colemak natively. A program to install the layout is available for Microsoft Windows. On Android and iOS, the layout is offered by several virtual keyboard apps like GBoard and SwiftKey, as well as by many apps which support physical keyboards directly. ",
+      "text": "Colemak is a keyboard layout for Latin-script alphabets. The layout is designed to make typing more efficient and comfortable by placing the most frequently used letters of the English language on the home row. Created in 2006, it is named after its inventor, Shai Coleman. Most major modern operating systems such as Mac OS, Linux, Android, Chrome OS, and BSD support Colemak natively. A program to install the layout is available for Microsoft Windows. On Android and iOS, the layout is offered by several virtual keyboard apps like GBoard and SwiftKey, as well as by many apps which support physical keyboards directly.",
       "source": "Wikipedia - Colemak",
-      "length": 623,
+      "length": 622,
       "id": 5735
     },
     {
@@ -34008,9 +34008,9 @@
       "id": 5738
     },
     {
-      "text": "Only in my darkest moments can I see the light. I think I'm prone to getting blinded when it's bright. Well, this December, I'll remember, want you to see it when I do. God knows I do. ",
+      "text": "Only in my darkest moments can I see the light. I think I'm prone to getting blinded when it's bright. Well, this December, I'll remember, want you to see it when I do. God knows I do.",
       "source": "This December- Ricky Montgomery ",
-      "length": 185,
+      "length": 184,
       "id": 5739
     },
     {
@@ -34038,7 +34038,7 @@
       "id": 5743
     },
     {
-      "text": "People don’t arrive broken. They start with passion and yearning until something comes along that disabuses them of those notions. People don’t have power over us. We give it to them.",
+      "text": "People don't arrive broken. They start with passion and yearning until something comes along that disabuses them of those notions. People don't have power over us. We give it to them.",
       "source": "Lucifer ",
       "length": 183,
       "id": 5744
@@ -34062,9 +34062,9 @@
       "id": 5747
     },
     {
-      "text": "This reversing the flow of time, doesn't us being here now, meant it never happened? ",
+      "text": "This reversing the flow of time, doesn't us being here now, meant it never happened?",
       "source": "The Protagonist, Tenet",
-      "length": 85,
+      "length": 84,
       "id": 5748
     },
     {
@@ -34092,7 +34092,7 @@
       "id": 5752
     },
     {
-      "text": "Listen to me, Morty. I know that new situations can be intimidating. You're lookin’ around and it’s all scary and different, but y’know… meeting them head-on, charging into ‘em like a bull — that’s how we grow as people.",
+      "text": "Listen to me, Morty. I know that new situations can be intimidating. You're lookin' around and it's all scary and different, but y'know... meeting them head-on, charging into 'em like a bull — that's how we grow as people.",
       "source": "Rick and Morty",
       "length": 221,
       "id": 5753
@@ -34146,7 +34146,7 @@
       "id": 5761
     },
     {
-      "text": "In a perfect world I’d have all ten fingers on my left hand, so my right would just be a fist for punching",
+      "text": "In a perfect world I'd have all ten fingers on my left hand, so my right would just be a fist for punching",
       "source": "The Office",
       "length": 106,
       "id": 5762
@@ -34164,9 +34164,9 @@
       "id": 5764
     },
     {
-      "text": "Appear weak when you are strong, and strong when you are weak. ",
+      "text": "Appear weak when you are strong, and strong when you are weak.",
       "source": "The Art of War",
-      "length": 63,
+      "length": 62,
       "id": 5765
     },
     {
@@ -34176,7 +34176,7 @@
       "id": 5766
     },
     {
-      "text": "Do I need to be liked? Absolutely not. I like to be liked. I enjoy being liked. I have to be liked. But it’s not like this compulsive need like my need to be praised.",
+      "text": "Do I need to be liked? Absolutely not. I like to be liked. I enjoy being liked. I have to be liked. But it's not like this compulsive need like my need to be praised.",
       "source": "The Office",
       "length": 166,
       "id": 5767
@@ -34206,9 +34206,9 @@
       "id": 5771
     },
     {
-      "text": "My mom always used to say that average people are the most special people in the world. And that's why God made so many of them. ",
+      "text": "My mom always used to say that average people are the most special people in the world. And that's why God made so many of them.",
       "source": "The Office",
-      "length": 129,
+      "length": 128,
       "id": 5772
     },
     {
@@ -34260,9 +34260,9 @@
       "id": 5780
     },
     {
-      "text": "When you become untouchable you are unable to touch. ",
+      "text": "When you become untouchable you are unable to touch.",
       "source": "My Ordinary Life (The Living Tombstones) ",
-      "length": 53,
+      "length": 52,
       "id": 5781
     },
     {
@@ -34272,9 +34272,9 @@
       "id": 5782
     },
     {
-      "text": "You're going to learn a lot of things. But it might be easier for you to keep living, if you didn't learn them, if you didn't know them. You don't realize your body is on fire and burning up because of the things you did. You'll understand one day. And then you'll realize for the first time that you have many burns. ",
+      "text": "You're going to learn a lot of things. But it might be easier for you to keep living, if you didn't learn them, if you didn't know them. You don't realize your body is on fire and burning up because of the things you did. You'll understand one day. And then you'll realize for the first time that you have many burns.",
       "source": "Violet Evergarden",
-      "length": 318,
+      "length": 317,
       "id": 5783
     },
     {
@@ -34362,7 +34362,7 @@
       "id": 5797
     },
     {
-      "text": "“There are many types of monsters in this world, monsters who will not show themselves and who cause trouble. Monsters who abduct children, monsters who devour dreams, monsters who suck blood, and monsters who always tell lies. Lying monsters are a real nuisance. They are much more cunning than other monsters. They pose as humans, even though they have no understanding of the human heart. They eat, even though they've never experienced hunger. They study even though the have no interest in academics. They seek friendship even though they do not know how to love. If I were to encounter such a monster, I would likely be eaten by it because, in truth, I am that monster.”\n",
+      "text": "\"There are many types of monsters in this world, monsters who will not show themselves and who cause trouble. Monsters who abduct children, monsters who devour dreams, monsters who suck blood, and monsters who always tell lies. Lying monsters are a real nuisance. They are much more cunning than other monsters. They pose as humans, even though they have no understanding of the human heart. They eat, even though they've never experienced hunger. They study even though the have no interest in academics. They seek friendship even though they do not know how to love. If I were to encounter such a monster, I would likely be eaten by it because, in truth, I am that monster.\"\n",
       "source": "Death Note",
       "length": 677,
       "id": 5798
@@ -34422,7 +34422,7 @@
       "id": 5807
     },
     {
-      "text": "“I’m like you,” he said. “I remember everything.” I stopped for a second. If you remember everything, I wanted to say, and if you are really like me, then before you leave tomorrow, or when you’re just ready to shut the door of the taxi and have already said goodbye to everyone else and there’s not a thing left to say in this life, then, just this once, turn to me, even in jest, or as an afterthought, which would have meant everything to me when we were together, and, as you did back then, look me in the face, hold my gaze, and call me by your name.",
+      "text": "\"I'm like you,\" he said. \"I remember everything.\" I stopped for a second. If you remember everything, I wanted to say, and if you are really like me, then before you leave tomorrow, or when you're just ready to shut the door of the taxi and have already said goodbye to everyone else and there's not a thing left to say in this life, then, just this once, turn to me, even in jest, or as an afterthought, which would have meant everything to me when we were together, and, as you did back then, look me in the face, hold my gaze, and call me by your name.",
       "source": "Call Me By Your Name",
       "length": 555,
       "id": 5808
@@ -34440,9 +34440,9 @@
       "id": 5810
     },
     {
-      "text": "Maybe the best thing to do is stop trying to figure out where you're going and just enjoy where you're at. ",
+      "text": "Maybe the best thing to do is stop trying to figure out where you're going and just enjoy where you're at.",
       "source": "Scrubs",
-      "length": 107,
+      "length": 106,
       "id": 5811
     },
     {
@@ -34458,7 +34458,7 @@
       "id": 5813
     },
     {
-      "text": "Youth is both a lie, and a form of evil. Those that glorify that youth are only fooling themselves and those around them, and believe that their surroundings always affirm their actions. By using the word “youth” they twist and distort common sense and anything logical. For them, lies, secrets, sins, and failures do nothing but add spice to their youth.",
+      "text": "Youth is both a lie, and a form of evil. Those that glorify that youth are only fooling themselves and those around them, and believe that their surroundings always affirm their actions. By using the word \"youth\" they twist and distort common sense and anything logical. For them, lies, secrets, sins, and failures do nothing but add spice to their youth.",
       "source": "Oregairu - Hikigaya Hachiman",
       "length": 355,
       "id": 5814
@@ -34512,9 +34512,9 @@
       "id": 5822
     },
     {
-      "text": "Look, it doesn't take a genius to know that every organization thrives when it has two leaders. Go ahead, name a country that doesn't have two presidents; a boat that sets sail without two captains. Where would Catholicism be, without the Popes? ",
+      "text": "Look, it doesn't take a genius to know that every organization thrives when it has two leaders. Go ahead, name a country that doesn't have two presidents; a boat that sets sail without two captains. Where would Catholicism be, without the Popes?",
       "source": "The Office",
-      "length": 246,
+      "length": 245,
       "id": 5823
     },
     {
@@ -34560,9 +34560,9 @@
       "id": 5830
     },
     {
-      "text": "If you love what you're doing, then you've already succeeded. ",
+      "text": "If you love what you're doing, then you've already succeeded.",
       "source": "Never Let it Die, Watsky",
-      "length": 62,
+      "length": 61,
       "id": 5831
     },
     {
@@ -34608,13 +34608,13 @@
       "id": 5838
     },
     {
-      "text": "Sometimes I feel like I’ve already seen everything that’s gonna happen and it’s a nightmare.",
+      "text": "Sometimes I feel like I've already seen everything that's gonna happen and it's a nightmare.",
       "source": "Cherry",
       "length": 92,
       "id": 5839
     },
     {
-      "text": "Sometimes I feel like love doesn’t actually exist. It’s just pheromones playing tricks on people.",
+      "text": "Sometimes I feel like love doesn't actually exist. It's just pheromones playing tricks on people.",
       "source": "Cherry",
       "length": 97,
       "id": 5840
@@ -34644,7 +34644,7 @@
       "id": 5844
     },
     {
-      "text": "I’ve seen what such feelings can do to a fully trained Jedi Knight. To the best of us.",
+      "text": "I've seen what such feelings can do to a fully trained Jedi Knight. To the best of us.",
       "source": "The Mandalorian",
       "length": 86,
       "id": 5845
@@ -34692,9 +34692,9 @@
       "id": 5852
     },
     {
-      "text": "\"The past is so much less terrifying than the future,\" he explained after some coaxing. \"Even the most terrifying terrible era of the past is at least knowable. It can be studied. The world survived it. But in the present, one never knows when the whole world survived it. But in the present, oe never knows when the whole world could come to a terrible, crashing end. ",
+      "text": "\"The past is so much less terrifying than the future,\" he explained after some coaxing. \"Even the most terrifying terrible era of the past is at least knowable. It can be studied. The world survived it. But in the present, one never knows when the whole world survived it. But in the present, oe never knows when the whole world could come to a terrible, crashing end.",
       "source": "A Map of Days",
-      "length": 369,
+      "length": 368,
       "id": 5853
     }
   ]


### PR DESCRIPTION
### Description

Removes trailing white space and fixes some remaining unicode quotation characters in `english.json`.

I used https://gist.github.com/connorjan/61d12889ffdf2eb372bf38e5fb1d87c2 to perform the fixes.