### PR TITLE
logo fixed to match gmk shadow novelties

### DIFF
--- a/static/themes/shadow.css
+++ b/static/themes/shadow.css
@@ -10,6 +10,14 @@
   --colorful-error-extra-color: #d8d8d8;
 }
 
+#top .logo .icon{
+  color: #8C3230;
+}
+
+#top .logo .text{
+  color: #557D8D;
+}
+
 @keyframes shadow {
   to {
     color: #000;


### PR DESCRIPTION
### Description
This change simply fixes the logo and text at the top left of the webpage. The original theme ignores the red novelty and blue text on the keycap set.
