### PR TITLE
added GMK Mecha_01 theme

### DIFF
--- a/static/themes/_list.json
+++ b/static/themes/_list.json
@@ -633,5 +633,10 @@
     "name": "modern_ink",
     "bgColor" : "#ffffff",
     "textColor":"#ff360d"
+  },
+  {
+    "name": "mecha_01",
+    "bgColor": "#7a05ff",
+    "textColor": "#a9a9a9"
   }
 ]

--- a/static/themes/mecha_01.css
+++ b/static/themes/mecha_01.css
@@ -1,0 +1,20 @@
+:root {
+  --bg-color: #7a05ff;
+  --main-color: #2aff19;
+  --caret-color: #2aff19;
+  --sub-color: #a9a9a9;
+  --text-color: #a9a9a9;
+  --error-color: #ff7000;
+  --error-extra-color: #ff201d;
+  --colorful-error-color: #ff940b;
+  --colorful-error-extra-color: #ff8f00;
+}
+
+#menu .icon-button:nth-child(1),
+#menu .icon-button:nth-child(2),
+#menu .icon-button:nth-child(3),
+#menu .icon-button:nth-child(4),
+#menu .icon-button:nth-child(5){
+  background: #2aff19;
+  color: #ff7000;
+}


### PR DESCRIPTION
Here's a photo of the Mecha_01 theme.

![image](https://user-images.githubusercontent.com/83473782/145083546-d4c87f63-4ed0-4ca9-8e8d-55bacfebe5ba.png)


### Description

This theme is based off GMK Mecha_01. It's color scheme is Bright orange, Indigo and Chartreuse green. I included the orange in the icon buttons next to the logo, as well as the errors to give the letters some more pop. As the indigo is the base in the keycap set I made it the background. Since it is quite a light purple I decided to exclude the black modifier from the theme to make it a bit of a lighter theme.
