### PR TITLE
Add lunar theme

### DIFF
--- a/static/themes/_list.json
+++ b/static/themes/_list.json
@@ -633,5 +633,10 @@
     "name": "modern_ink",
     "bgColor" : "#ffffff",
     "textColor":"#ff360d"
+  },
+  {
+    "name": "lunar",
+    "bgColor" : "#161616",
+    "textColor":"#3281ea"
   }
 ]

--- a/static/themes/lunar.css
+++ b/static/themes/lunar.css
@@ -1,0 +1,12 @@
+/*theme called Lunar based on the Lunar color scheme by sheeepdev : "https://github.com/lunar-theme".*/
+:root {
+    --bg-color: #161616;
+    --main-color: #3281ea;
+    --caret-color: #3281ea;
+    --sub-color: #D8DEE9;
+    --text-color: #ECEFF4;
+    --error-color: #B10C0C;
+    --error-extra-color: #640606;
+    --colorful-error-color: #05844A;
+    --colorful-error-extra-color: #03512d;
+}


### PR DESCRIPTION
Here is a screenshot:

![1](https://i.imgur.com/owj0uxB.png)

<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description
I have seen this amazing typing website Monkeytype, it is really nice, so I made a theme called Lunar based on the Lunar color scheme by @sheeepdev : "https://github.com/lunar-theme". in brief, what I did is just modify the colors.
<!-- Please describe the change(s) made in your PR -->


<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/Miodec/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
