### PR TITLE
Add Option to Use MongoDB Credentials

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,8 @@ Follow these steps if you want to work on anything involving the database/accoun
 
 1. Inside the backend folder, copy `example.env` to `.env` in the same directory.
 
+   1. If necessary, uncomment the lines in the `.env` file to use credentials to login to MongoDB.
+
 1. Optional - Install [MongoDB-compass](https://www.mongodb.com/try/download/compass?tck=docs_compass). This tool can be used to see and manipulate your data visually.
    1. To connect, type `mongodb://localhost:27017` in the connection string box and press connect. The monkeytype database will be created and shown` after the server is started`.
 

--- a/backend/example.env
+++ b/backend/example.env
@@ -1,2 +1,8 @@
 DB_URI=mongodb://localhost:27017
 DB_NAME=monkeytype
+
+# Uncomment the following lines if you need credentials to login to MongoDB
+# DB_USERNAME=
+# DB_PASSWORD=
+# DB_AUTH_MECHANISM="SCRAM-SHA-256"
+# DB_AUTH_SOURCE=admin

--- a/backend/example.env
+++ b/backend/example.env
@@ -1,7 +1,7 @@
-DB_URI=mongodb://localhost:27017
 DB_NAME=monkeytype
-
-# Uncomment the following lines if you need credentials to login to MongoDB
+DB_URI=mongodb://localhost:27017
+# You can also use the format mongodb://username:password@host:port or
+# uncomment the following lines if you want to define them separately
 # DB_USERNAME=
 # DB_PASSWORD=
 # DB_AUTH_MECHANISM="SCRAM-SHA-256"

--- a/backend/init/mongodb.js
+++ b/backend/init/mongodb.js
@@ -4,10 +4,27 @@ let mongoClient;
 
 module.exports = {
   async connectDB() {
-    return MongoClient.connect(process.env.DB_URI, {
+    let options = {
       useNewUrlParser: true,
       useUnifiedTopology: true,
-    })
+    };
+
+    if (process.env.DB_USERNAME && process.env.DB_PASSWORD) {
+      options.auth = {
+        username: process.env.DB_USERNAME,
+        password: process.env.DB_PASSWORD,
+      };
+    }
+
+    if (process.env.DB_AUTH_MECHANISM) {
+      options.authMechanism = process.env.DB_AUTH_MECHANISM;
+    }
+
+    if (process.env.DB_AUTH_SOURCE) {
+      options.authSource = process.env.DB_AUTH_SOURCE;
+    }
+
+    return MongoClient.connect(process.env.DB_URI, options)
       .then((client) => {
         mongoClient = client;
       })


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

I have added the option to use MongoDB credentials to login to MongoDB. This is for people who have MongoDB locked with a password.

The new `.env`entries are:

1. DB_USERNAME
1. DB_PASSWORD
1. DB_AUTH_MECHANISM
1. DB_AUTH_SOURCE

<!-- Please describe the change(s) made in your PR -->

Closes #

This is a redo of [this PR](https://github.com/Miodec/monkeytype/pull/2167) that doesn't have unrelated changes.

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/Miodec/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
