### PR TITLE
Add Retry Saving Result Button

### DIFF
--- a/src/js/test/test-logic.js
+++ b/src/js/test/test-logic.js
@@ -2210,6 +2210,8 @@ export async function finish(difficultyFailed = false) {
     }
   }
 
+  $("#retrySavingResultButton").addClass("hidden");
+
   if (firebase.auth().currentUser != null) {
     $("#result .loginTip").addClass("hidden");
   } else {

--- a/src/js/test/test-logic.js
+++ b/src/js/test/test-logic.js
@@ -1263,6 +1263,114 @@ export async function addWord() {
   }
 }
 
+function retrySavingResult(
+  completedEvent,
+  testtime,
+  afkseconds,
+  pbDiff,
+  mode2,
+  stats,
+  consistency
+) {
+  if (!completedEvent) {
+    Notifications.add(
+      "Could not retry saving the result as the result no longer exists.",
+      0,
+      -1
+    );
+  }
+
+  AccountButton.loading(true);
+
+  Notifications.add("Retrying to save...");
+
+  axiosInstance
+    .post("/results/add", {
+      result: completedEvent,
+    })
+    .then((response) => {
+      AccountButton.loading(false);
+
+      if (response.status !== 200) {
+        Notifications.add("Result not saved. " + response.data.message, -1);
+      } else {
+        completedEvent._id = response.data.insertedId;
+        if (
+          response.data.isPb &&
+          ["english"].includes(completedEvent.language)
+        ) {
+          completedEvent.isPb = true;
+        }
+        if (
+          DB.getSnapshot() !== null &&
+          DB.getSnapshot().results !== undefined
+        ) {
+          DB.getSnapshot().results.unshift(completedEvent);
+          if (DB.getSnapshot().globalStats.time == undefined) {
+            DB.getSnapshot().globalStats.time =
+              testtime + completedEvent.incompleteTestSeconds - afkseconds;
+          } else {
+            DB.getSnapshot().globalStats.time +=
+              testtime + completedEvent.incompleteTestSeconds - afkseconds;
+          }
+          if (DB.getSnapshot().globalStats.started == undefined) {
+            DB.getSnapshot().globalStats.started = TestStats.restartCount + 1;
+          } else {
+            DB.getSnapshot().globalStats.started += TestStats.restartCount + 1;
+          }
+          if (DB.getSnapshot().globalStats.completed == undefined) {
+            DB.getSnapshot().globalStats.completed = 1;
+          } else {
+            DB.getSnapshot().globalStats.completed += 1;
+          }
+        }
+        try {
+          firebase.analytics().logEvent("testCompleted", completedEvent);
+        } catch (e) {
+          console.log("Analytics unavailable");
+        }
+
+        if (response.data.isPb) {
+          //new pb
+          PbCrown.show();
+          $("#result .stats .wpm .crown").attr(
+            "aria-label",
+            "+" + Misc.roundTo2(pbDiff)
+          );
+          DB.saveLocalPB(
+            Config.mode,
+            mode2,
+            Config.punctuation,
+            Config.language,
+            Config.difficulty,
+            Config.lazyMode,
+            stats.wpm,
+            stats.acc,
+            stats.wpmRaw,
+            consistency
+          );
+        } else {
+          PbCrown.hide();
+          // if (localPb) {
+          //   Notifications.add(
+          //     "Local PB data is out of sync! Refresh the page to resync it or contact Miodec on Discord.",
+          //     15000
+          //   );
+          // }
+        }
+      }
+      $("#retrySavingResultButton").addClass("hidden");
+      $(document.body).off("click", "#retrySavingResultButton", false);
+      Notifications.add("Result successfully saved!");
+    })
+    .catch((e) => {
+      AccountButton.loading(false);
+      let msg = e?.response?.data?.message ?? e.message;
+      Notifications.add("Failed to save result: " + msg, -1);
+      $("#retrySavingResultButton").removeClass("hidden");
+    });
+}
+
 export async function finish(difficultyFailed = false) {
   if (!active) return;
   if (Config.mode == "zen" && input.current.length != 0) {
@@ -2047,6 +2155,18 @@ export async function finish(difficultyFailed = false) {
                 AccountButton.loading(false);
                 let msg = e?.response?.data?.message ?? e.message;
                 Notifications.add("Failed to save result: " + msg, -1);
+                $("#retrySavingResultButton").removeClass("hidden");
+                $(document.body).on("click", "#retrySavingResultButton", () => {
+                  retrySavingResult(
+                    completedEvent,
+                    testtime,
+                    afkseconds,
+                    pbDiff,
+                    mode2,
+                    stats,
+                    consistency
+                  );
+                });
               });
           });
         });

--- a/src/js/test/test-ui.js
+++ b/src/js/test/test-ui.js
@@ -1036,10 +1036,7 @@ $(document).on("keypress", "#restartTestButton", (event) => {
 });
 
 $(document.body).on("click", "#restartTestButton", () => {
-  if (!$("#retrySavingResultButton").hasClass("hidden")) {
-    $("#retrySavingResultButton").addClass("hidden");
-  }
-  $(document.body).off("click", "#retrySavingResultButton", false);
+  $("#retrySavingResultButton").addClass("hidden");
   ManualRestart.set();
   if (resultCalculating) return;
   if (
@@ -1052,6 +1049,12 @@ $(document.body).on("click", "#restartTestButton", () => {
     TestLogic.restart();
   }
 });
+
+$(document.body).on(
+  "click",
+  "#retrySavingResultButton",
+  TestLogic.retrySavingResult
+);
 
 $(document).on("keypress", "#practiseWordsButton", (event) => {
   if (event.keyCode == 13) {
@@ -1071,10 +1074,7 @@ $(document).on("keypress", "#nextTestButton", (event) => {
 });
 
 $(document.body).on("click", "#nextTestButton", () => {
-  if (!$("#retrySavingResultButton").hasClass("hidden")) {
-    $("#retrySavingResultButton").addClass("hidden");
-  }
-  $(document.body).off("click", "#retrySavingResultButton", false);
+  $("#retrySavingResultButton").addClass("hidden");
   ManualRestart.set();
   TestLogic.restart();
 });

--- a/src/js/test/test-ui.js
+++ b/src/js/test/test-ui.js
@@ -1036,6 +1036,10 @@ $(document).on("keypress", "#restartTestButton", (event) => {
 });
 
 $(document.body).on("click", "#restartTestButton", () => {
+  if (!$("#retrySavingResultButton").hasClass("hidden")) {
+    $("#retrySavingResultButton").addClass("hidden");
+  }
+  $(document.body).off("click", "#retrySavingResultButton", false);
   ManualRestart.set();
   if (resultCalculating) return;
   if (
@@ -1067,6 +1071,10 @@ $(document).on("keypress", "#nextTestButton", (event) => {
 });
 
 $(document.body).on("click", "#nextTestButton", () => {
+  if (!$("#retrySavingResultButton").hasClass("hidden")) {
+    $("#retrySavingResultButton").addClass("hidden");
+  }
+  $(document.body).off("click", "#retrySavingResultButton", false);
   ManualRestart.set();
   TestLogic.restart();
 });

--- a/src/js/test/test-ui.js
+++ b/src/js/test/test-ui.js
@@ -1036,7 +1036,6 @@ $(document).on("keypress", "#restartTestButton", (event) => {
 });
 
 $(document.body).on("click", "#restartTestButton", () => {
-  $("#retrySavingResultButton").addClass("hidden");
   ManualRestart.set();
   if (resultCalculating) return;
   if (
@@ -1074,7 +1073,6 @@ $(document).on("keypress", "#nextTestButton", (event) => {
 });
 
 $(document.body).on("click", "#nextTestButton", () => {
-  $("#retrySavingResultButton").addClass("hidden");
   ManualRestart.set();
   TestLogic.restart();
 });

--- a/src/sass/test.scss
+++ b/src/sass/test.scss
@@ -837,20 +837,26 @@
   position: relative;
   border-radius: var(--roundness);
   padding: 1rem 2rem;
-  width: min-content;
-  width: -moz-min-content;
   color: var(--error-color);
   transition: 0.25s;
   cursor: pointer;
+  width: max-content;
+  width: -moz-max-content;
+  background: var(--colorful-error-color);
+  color: var(--bg-color);
+  justify-self: center;
+  justify-content: center;
+  margin: 0 auto 1rem auto;
+  user-select: none;
 
   &:hover,
   &:focus {
-    color: var(--main-color);
+    background: var(--text-color);
     outline: none;
   }
 
   &:focus {
-    background: var(--sub-color);
+    background: var(--text-color);
   }
 }
 

--- a/src/sass/test.scss
+++ b/src/sass/test.scss
@@ -833,6 +833,27 @@
   }
 }
 
+#retrySavingResultButton {
+  position: relative;
+  border-radius: var(--roundness);
+  padding: 1rem 2rem;
+  width: min-content;
+  width: -moz-min-content;
+  color: var(--error-color);
+  transition: 0.25s;
+  cursor: pointer;
+
+  &:hover,
+  &:focus {
+    color: var(--main-color);
+    outline: none;
+  }
+
+  &:focus {
+    background: var(--sub-color);
+  }
+}
+
 #showWordHistoryButton {
   opacity: 1;
 }

--- a/static/index.html
+++ b/static/index.html
@@ -1366,6 +1366,15 @@
                     <div id="replayWords" class="words"></div>
                   </div>
                 </div>
+                <div
+                  id="retrySavingResultButton"
+                  class="hidden"
+                  tabindex="0"
+                  onclick="this.blur();"
+                >
+                  <i class="fas fa-redo"></i>
+                  Retry saving result
+                </div>
                 <div class="buttons">
                   <div
                     id="nextTestButton"
@@ -1420,16 +1429,6 @@
                     onclick="this.blur();"
                   >
                     <i class="far fa-fw fa-image"></i>
-                  </div>
-                  <div
-                    id="retrySavingResultButton"
-                    class="hidden"
-                    aria-label="Retry saving result"
-                    data-balloon-pos="down"
-                    tabindex="0"
-                    onclick="this.blur();"
-                  >
-                    <i class="fas fa-redo"></i>
                   </div>
                 </div>
               </div>

--- a/static/index.html
+++ b/static/index.html
@@ -1421,6 +1421,16 @@
                   >
                     <i class="far fa-fw fa-image"></i>
                   </div>
+                  <div
+                    id="retrySavingResultButton"
+                    class="hidden"
+                    aria-label="Retry saving result"
+                    data-balloon-pos="down"
+                    tabindex="0"
+                    onclick="this.blur();"
+                  >
+                    <i class="fas fa-redo"></i>
+                  </div>
                 </div>
               </div>
               <div class="ssWatermark hidden">monkeytype.com</div>


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

### Description

<!-- Please describe the change(s) made in your PR -->

![Screenshot 2021-12-10 212829](https://user-images.githubusercontent.com/64989416/145662394-a7321b0b-8652-4e0d-b32c-34d0c9717524.png)

This PR adds a button that will retry to save a result that has failed to save. The red redo button only shows up when a test has failed to save and will hide itself again when the result has saved. When it has succeeded in saving the result it should remove the click listener. I have tested this by disconnecting from the internet, doing a 10 word test, trying the button, reconnecting to the internet, and trying the button again.

There might be some bugs. For example, the button may activate twice. So this still might need some work.

Closes [#2166](https://github.com/Miodec/monkeytype/issues/2166)

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/Miodec/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
