### PR TITLE
Add Capslock Indicator Settings Option

### DIFF
--- a/src/js/commandline-lists.js
+++ b/src/js/commandline-lists.js
@@ -1625,24 +1625,24 @@ let commandsSingleListCommandLine = {
   ],
 };
 
-let commandsCapsLockIndicator = {
-  title: "Caps lock indicator...",
-  configKey: "capsLockIndicator",
+let commandsCapsLockWarning = {
+  title: "Caps lock warning...",
+  configKey: "capsLockWarning",
   list: [
     {
-      id: "capsLockIndicatorOn",
+      id: "capsLockWarningOn",
       display: "on",
       configValue: true,
       exec: () => {
-        UpdateConfig.setCapsLockIndicator(true);
+        UpdateConfig.setCapsLockWarning(true);
       },
     },
     {
-      id: "capsLockIndicatorOff",
+      id: "capsLockWarningOff",
       display: "off",
       configValue: false,
       exec: () => {
-        UpdateConfig.setCapsLockIndicator(false);
+        UpdateConfig.setCapsLockWarning(false);
       },
     },
   ],
@@ -2553,10 +2553,10 @@ export let defaultCommands = {
       subgroup: commandsSingleListCommandLine,
     },
     {
-      id: "capsLockIndicator",
-      display: "Caps lock indicator...",
+      id: "capsLockWarning",
+      display: "Caps lock warning...",
       icon: "fa-exclamation-triangle",
-      subgroup: commandsCapsLockIndicator,
+      subgroup: commandsCapsLockWarning,
     },
     {
       id: "changeMinWpm",

--- a/src/js/commandline-lists.js
+++ b/src/js/commandline-lists.js
@@ -1625,6 +1625,29 @@ let commandsSingleListCommandLine = {
   ],
 };
 
+let commandsCapsLockIndicator = {
+  title: "Caps lock indicator...",
+  configKey: "capsLockIndicator",
+  list: [
+    {
+      id: "capsLockIndicatorOn",
+      display: "on",
+      configValue: true,
+      exec: () => {
+        UpdateConfig.setCapsLockIndicator(true);
+      },
+    },
+    {
+      id: "capsLockIndicatorOff",
+      display: "off",
+      configValue: false,
+      exec: () => {
+        UpdateConfig.setCapsLockIndicator(false);
+      },
+    },
+  ],
+};
+
 let commandsTimerOpacity = {
   title: "Timer/progress opacity...",
   configKey: "timerOpacity",
@@ -2528,6 +2551,12 @@ export let defaultCommands = {
       display: "Single list command line...",
       icon: "fa-list",
       subgroup: commandsSingleListCommandLine,
+    },
+    {
+      id: "capsLockIndicator",
+      display: "Caps lock indicator...",
+      icon: "fa-exclamation-triangle",
+      subgroup: commandsCapsLockIndicator,
     },
     {
       id: "changeMinWpm",

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -96,6 +96,7 @@ let defaultConfig = {
   alwaysShowDecimalPlaces: false,
   alwaysShowWordsHistory: false,
   singleListCommandLine: "manual",
+  capsLockIndicator: true,
   playSoundOnError: false,
   playSoundOnClick: "off",
   startGraphsAtZero: true,
@@ -632,6 +633,24 @@ export function setSingleListCommandLine(option, nosave) {
   if (!option) option = "manual";
   config.singleListCommandLine = option;
   if (!nosave) saveToLocalStorage();
+}
+
+//caps lock indicator
+export function setCapsLockIndicator(val, nosave) {
+  if (val == undefined) {
+    val = false;
+  }
+  config.capsLockIndicator = val;
+  if (!nosave) saveToLocalStorage();
+}
+
+export function toggleCapsLockIndicator() {
+  let val = !config.capsLockIndicator;
+  if (val == "undefined") {
+    val = true;
+  }
+  config.capsLockIndicator = val;
+  saveToLocalStorage();
 }
 
 //show all lines
@@ -1657,6 +1676,7 @@ export function apply(configObj) {
     setAlwaysShowDecimalPlaces(configObj.alwaysShowDecimalPlaces, true);
     setAlwaysShowWordsHistory(configObj.alwaysShowWordsHistory, true);
     setSingleListCommandLine(configObj.singleListCommandLine, true);
+    setCapsLockIndicator(configObj.capsLockIndicator, true);
     setPlaySoundOnError(configObj.playSoundOnError, true);
     setPlaySoundOnClick(configObj.playSoundOnClick, true);
     setStopOnError(configObj.stopOnError, true);

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -96,7 +96,7 @@ let defaultConfig = {
   alwaysShowDecimalPlaces: false,
   alwaysShowWordsHistory: false,
   singleListCommandLine: "manual",
-  capsLockIndicator: true,
+  capsLockWarning: true,
   playSoundOnError: false,
   playSoundOnClick: "off",
   startGraphsAtZero: true,
@@ -635,22 +635,13 @@ export function setSingleListCommandLine(option, nosave) {
   if (!nosave) saveToLocalStorage();
 }
 
-//caps lock indicator
-export function setCapsLockIndicator(val, nosave) {
+//caps lock warning
+export function setCapsLockWarning(val, nosave) {
   if (val == undefined) {
     val = false;
   }
-  config.capsLockIndicator = val;
+  config.capsLockWarning = val;
   if (!nosave) saveToLocalStorage();
-}
-
-export function toggleCapsLockIndicator() {
-  let val = !config.capsLockIndicator;
-  if (val == "undefined") {
-    val = true;
-  }
-  config.capsLockIndicator = val;
-  saveToLocalStorage();
 }
 
 //show all lines
@@ -1676,7 +1667,7 @@ export function apply(configObj) {
     setAlwaysShowDecimalPlaces(configObj.alwaysShowDecimalPlaces, true);
     setAlwaysShowWordsHistory(configObj.alwaysShowWordsHistory, true);
     setSingleListCommandLine(configObj.singleListCommandLine, true);
-    setCapsLockIndicator(configObj.capsLockIndicator, true);
+    setCapsLockWarning(configObj.capsLockWarning, true);
     setPlaySoundOnError(configObj.playSoundOnError, true);
     setPlaySoundOnClick(configObj.playSoundOnClick, true);
     setStopOnError(configObj.stopOnError, true);

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -139,6 +139,10 @@ async function initGroups() {
     "singleListCommandLine",
     UpdateConfig.setSingleListCommandLine
   );
+  groups.capsLockIndicator = new SettingsGroup(
+    "capsLockIndicator",
+    UpdateConfig.setCapsLockIndicator
+  );
   groups.flipTestColors = new SettingsGroup(
     "flipTestColors",
     UpdateConfig.setFlipTestColors

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -139,9 +139,9 @@ async function initGroups() {
     "singleListCommandLine",
     UpdateConfig.setSingleListCommandLine
   );
-  groups.capsLockIndicator = new SettingsGroup(
-    "capsLockIndicator",
-    UpdateConfig.setCapsLockIndicator
+  groups.capsLockWarning = new SettingsGroup(
+    "capsLockWarning",
+    UpdateConfig.setCapsLockWarning
   );
   groups.flipTestColors = new SettingsGroup(
     "flipTestColors",

--- a/src/js/test/caps-warning.js
+++ b/src/js/test/caps-warning.js
@@ -1,3 +1,5 @@
+import Config from "./config";
+
 function show() {
   if ($("#capsWarning").hasClass("hidden")) {
     $("#capsWarning").removeClass("hidden");
@@ -12,7 +14,10 @@ function hide() {
 
 $(document).keydown(function (event) {
   try {
-    if (event.originalEvent.getModifierState("CapsLock")) {
+    if (
+      event.originalEvent.getModifierState("CapsLock") &&
+      Config.capsLockIndicator
+    ) {
       show();
     } else {
       hide();

--- a/src/js/test/caps-warning.js
+++ b/src/js/test/caps-warning.js
@@ -16,7 +16,7 @@ $(document).keydown(function (event) {
   try {
     if (
       event.originalEvent.getModifierState("CapsLock") &&
-      Config.capsLockIndicator
+      Config.capsLockWarning
     ) {
       show();
     } else {

--- a/static/index.html
+++ b/static/index.html
@@ -3990,8 +3990,8 @@
                   </div>
                 </div>
               </div>
-              <div class="section capsLockIndicator">
-                <h1>caps lock indicator</h1>
+              <div class="section capsLockWarning">
+                <h1>caps lock warning</h1>
                 <div class="text">Displays a warning when caps lock is on.</div>
                 <div class="buttons">
                   <div class="button off" tabindex="0" onclick="this.blur();">

--- a/static/index.html
+++ b/static/index.html
@@ -2293,6 +2293,22 @@
                   </div>
                 </div>
               </div>
+              <div class="section capsLockIndicator">
+                <h1>caps lock indicator</h1>
+                <div class="text">
+                  When enabled, it will indicate when you have your
+                  <key>caps lock</key>
+                  on.
+                </div>
+                <div class="buttons">
+                  <div class="button off" tabindex="0" onclick="this.blur();">
+                    off
+                  </div>
+                  <div class="button on" tabindex="0" onclick="this.blur();">
+                    on
+                  </div>
+                </div>
+              </div>
               <div class="section minWpm" section="">
                 <h1>min wpm</h1>
                 <div class="text">

--- a/static/index.html
+++ b/static/index.html
@@ -2293,22 +2293,6 @@
                   </div>
                 </div>
               </div>
-              <div class="section capsLockIndicator">
-                <h1>caps lock indicator</h1>
-                <div class="text">
-                  When enabled, it will indicate when you have your
-                  <key>caps lock</key>
-                  on.
-                </div>
-                <div class="buttons">
-                  <div class="button off" tabindex="0" onclick="this.blur();">
-                    off
-                  </div>
-                  <div class="button on" tabindex="0" onclick="this.blur();">
-                    on
-                  </div>
-                </div>
-              </div>
               <div class="section minWpm" section="">
                 <h1>min wpm</h1>
                 <div class="text">
@@ -4003,6 +3987,18 @@
                   </div>
                   <div class="button on" tabindex="0" onclick="this.blur();">
                     show
+                  </div>
+                </div>
+              </div>
+              <div class="section capsLockIndicator">
+                <h1>caps lock indicator</h1>
+                <div class="text">Displays a warning when caps lock is on.</div>
+                <div class="buttons">
+                  <div class="button off" tabindex="0" onclick="this.blur();">
+                    off
+                  </div>
+                  <div class="button on" tabindex="0" onclick="this.blur();">
+                    on
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

<!-- Please describe the change(s) made in your PR -->

This adds the option to disable the capslock indicator that shows when typing. The default option is having it on. The option is under the "behavior" settings group.
