### PR TITLE
Added functionality so that you fail on incorrect opposite shift for master and expert mode

### DIFF
--- a/src/js/input-controller.js
+++ b/src/js/input-controller.js
@@ -428,7 +428,7 @@ function handleChar(char, charIndex) {
     }
   }
 
-  if (!correctShiftUsed) return;
+  if (!correctShiftUsed && Config.difficulty == "normal") return;
 
   //update current corrected version. if its empty then add the current char. if its not then replace the last character with the currently pressed one / add it
   if (TestLogic.corrected.current === "") {

--- a/src/js/input-controller.js
+++ b/src/js/input-controller.js
@@ -428,7 +428,7 @@ function handleChar(char, charIndex) {
     }
   }
 
-  if (!correctShiftUsed && Config.difficulty == "normal") return;
+  if (!correctShiftUsed && Config.difficulty != "master") return;
 
   //update current corrected version. if its empty then add the current char. if its not then replace the last character with the currently pressed one / add it
   if (TestLogic.corrected.current === "") {


### PR DESCRIPTION
### Description

<!-- Please describe the change(s) made in your PR -->
Closes #2181

This pr doesn't solve the problem in a particularly nice way because it may not be obvious to the user how they failed the test. I am not sure exactly how to solve this one however because it seems that the opposite shift functionality and the master/expert mode are at odds which each other. The idea of the opposite shift settings is that is doesn't type incorrect opposite shifts where as the idea of master mode is a focus on typing EVERY letter correctly. So idk, here's my attempt though.
![image](https://user-images.githubusercontent.com/49330942/146614066-bf4ac7f6-dd50-4267-877a-7ec526aacb4a.png)