### PR TITLE
Fix for Wikipedia newline issue

### DIFF
--- a/src/js/test/wikipedia.js
+++ b/src/js/test/wikipedia.js
@@ -46,6 +46,11 @@ export async function getSection() {
           sectionText = sectionText.replace(/\s+/g, " ");
           sectionText = sectionText.trim();
 
+          // Add spaces
+          sectionText = sectionText.replace(/[a-zA-Z0-9]{3,}\.[a-zA-Z]/g, (x) =>
+            x.replace(/\./, ". ")
+          );
+
           sectionText.split(" ").forEach((word) => {
             words.push(word);
           });


### PR DESCRIPTION

### Description
This PR uses regex to try and replace the missing gap in the wikipedia text. It looks for a word or number that is at least three characters long (to prevent "PH.D" being picked up), followed by a "." followed by a letter (not a number to prevent decimals being picked up). This however is not fool proof, as I have discovered that wikipedia articles are the mother of edge cases and so when I was testing I got this problem.
![image](https://user-images.githubusercontent.com/49330942/146655672-a61390ee-530c-42c1-801d-99e81809d223.png)
(The arrow is just so that I know that it was my regex that is changing the text, it is a space in the pr)

I don't think that this properly solves the issue and I don't think that any amount of regex will be able to get all the edge cases but I would say that this is better than before.

Closes #2112


