### PR TITLE
Completely Fix Wikipedia Spacing

### DIFF
--- a/src/js/test/wikipedia.js
+++ b/src/js/test/wikipedia.js
@@ -30,7 +30,7 @@ export async function getSection() {
       rej(randomPostReq.status);
     }
 
-    const sectionURL = `https://en.wikipedia.org/w/api.php?action=query&format=json&pageids=${pageid}&prop=extracts&exintro=true&explaintext=true&origin=*`;
+    const sectionURL = `https://en.wikipedia.org/w/api.php?action=query&format=json&pageids=${pageid}&prop=extracts&exintro=true&origin=*`;
 
     var sectionReq = new XMLHttpRequest();
     sectionReq.onload = () => {
@@ -42,14 +42,16 @@ export async function getSection() {
           let words = [];
 
           // Remove non-ascii characters, double whitespaces and finally trailing whitespaces.
+          sectionText = sectionText.replace(/<\/p><p>+/g, " ");
+          sectionText = $("<div/>").html(sectionText).text();
           sectionText = sectionText.replace(/[\u{0080}-\u{10FFFF}]/gu, "");
           sectionText = sectionText.replace(/\s+/g, " ");
           sectionText = sectionText.trim();
 
-          // Add spaces
-          sectionText = sectionText.replace(/[a-zA-Z0-9]{3,}\.[a-zA-Z]/g, (x) =>
-            x.replace(/\./, ". ")
-          );
+          // // Add spaces
+          // sectionText = sectionText.replace(/[a-zA-Z0-9]{3,}\.[a-zA-Z]/g, (x) =>
+          //   x.replace(/\./, ". ")
+          // );
 
           sectionText.split(" ").forEach((word) => {
             words.push(word);


### PR DESCRIPTION
### Description

<!-- Please describe the change(s) made in your PR -->

I don't know if what I'm doing isn't great practice but what I'm doing is not taking Wikipedia's way of turning the HTML into text and instead asking for the HTML (removing `explaintext=true` in the URL). Then I replace every instance where there's a new paragraph (`</p><p>`) with a space, and convert the HTML back into text. One problem I see with this is that if there's a pronunciation or a measure with a unit it will remove the space between it (eg. 12 km -> 12km) . This does consistently add the space between paragraphs and does not confuse acronyms, though.

Closes #2112 and extends on PR [#2193](https://github.com/Miodec/monkeytype/pull/2193)