### PR TITLE
Added redirect to quote submission page when a language has no quotes

### DIFF
--- a/src/js/test/test-logic.js
+++ b/src/js/test/test-logic.js
@@ -20,6 +20,7 @@ import * as TimerProgress from "./timer-progress";
 import * as ChartController from "./chart-controller";
 import * as UI from "./ui";
 import * as QuoteSearchPopup from "./quote-search-popup";
+import * as QuoteSubmitPopup from "./quote-submit-popup";
 import * as PbCrown from "./pb-crown";
 import * as TestTimer from "./test-timer";
 import * as OutOfFocus from "./out-of-focus";
@@ -970,11 +971,14 @@ export async function init() {
     let quotes = await Misc.getQuotes(Config.language.replace(/_\d*k$/g, ""));
 
     if (quotes.length === 0) {
+      TestUI.setTestRestarting(false);
       Notifications.add(
         `No ${Config.language.replace(/_\d*k$/g, "")} quotes found`,
         0
       );
-      TestUI.setTestRestarting(false);
+      if (firebase.auth().currentUser) {
+        QuoteSubmitPopup.show(false);
+      }
       UpdateConfig.setMode("words");
       restart();
       return;


### PR DESCRIPTION

### Description

<!-- Please describe the change(s) made in your PR -->
A fix for the issue mentioned [here](https://discord.com/channels/713194177403420752/713195089303830548/922167641609744404) and [here](https://discord.com/channels/713194177403420752/713195115275091969/922076092477607996). The changes made in this pr mean the website redirects authenticated users to the submit a quote popup if no quotes exist for the language they have selected.