### PR TITLE
Add scrolling to top after test restarts

### DIFF
--- a/src/js/test/test-logic.js
+++ b/src/js/test/test-logic.js
@@ -593,6 +593,7 @@ export function restart(
       $("#monkey").stop(true, true).css({ animationDuration: "0s" });
       $("#typingTest").css("opacity", 0).removeClass("hidden");
       $("#wordsInput").val(" ");
+      if(window.scrollY > 0) window.scrollTo({ top: 0, behavior: "smooth" });
       if (!withSameWordset) {
         setRepeated(false);
         setPaceRepeat(repeatWithPace);
@@ -712,7 +713,6 @@ export function restart(
         );
     }
   );
-  window.scrollTo({ top: 0, behavior: "smooth" });
 }
 
 export async function init() {

--- a/src/js/test/test-logic.js
+++ b/src/js/test/test-logic.js
@@ -712,6 +712,7 @@ export function restart(
         );
     }
   );
+  window.scrollTo({ top: 0, behavior: "smooth" });
 }
 
 export async function init() {


### PR DESCRIPTION
### Description

With a large font size or a high word count, the page would go down to the bottom upon restart, this was very annoying for me. So, I added a simple line to scroll to the top of the page after the test restarts.