### PR TITLE
Added google analytics to no cache list

### DIFF
--- a/static/sw.js
+++ b/static/sw.js
@@ -13,7 +13,7 @@ self.addEventListener("install", (event) => {
 self.addEventListener("fetch", async (event) => {
   const host = new URL(event.request.url).host;
   if (
-    ["localhost:5005", "api.monkeytype.com", "api.github.com"].includes(host)
+    ["localhost:5005", "api.monkeytype.com", "api.github.com", "www.google-analytics.com"].includes(host)
   ) {
     // if hostname is a non-static api, fetch request
     event.respondWith(fetch(event.request));


### PR DESCRIPTION
Fixed google analytics requests being cached when they shouldn't be. If in the future, you want to see which responses are being saved to cache, you can go to the `Storage` tab of the Firefox developer tools and select `Cache Storage` -> `https://monkeytype.com` -> `sw-cache`
![Screenshot from 2022-01-01 15-30-52](https://user-images.githubusercontent.com/47042841/147859628-45bd5b98-9887-4d77-bc8b-c59d44173ca0.png)

