### PR TITLE
Correct button text animations

### DIFF
--- a/src/sass/popups.scss
+++ b/src/sass/popups.scss
@@ -726,7 +726,7 @@
         gap: 1rem;
         text-decoration: none;
         .text {
-          transform: 0.25s;
+          transition: 0.25s;
         }
         &:hover .text {
           color: var(--bg-color);
@@ -797,7 +797,7 @@
         .text {
           font-size: 1.5rem;
           line-height: 2rem;
-          transform: 0.25s;
+          transition: 0.25s;
         }
         &:hover .text {
           color: var(--bg-color);


### PR DESCRIPTION
## Description
Css properties of button text were set to `transform: 0.25s`. This is invalid and `transition: 0.25s` is likely what the code was intended to say.