### PR TITLE
Replaced call to nonexistent function Misc.countAllKeys

### DIFF
--- a/src/js/account/result-filters.js
+++ b/src/js/account/result-filters.js
@@ -75,8 +75,8 @@ function load() {
     if (
       newResultFilters != undefined &&
       newResultFilters !== "" &&
-      Misc.countAllKeys(newResultFilters) >=
-        Misc.countAllKeys(defaultResultFilters)
+      Object.keys(JSON.parse(newResultFilters)).length >=
+        Object.keys(defaultResultFilters).length
     ) {
       filters = JSON.parse(newResultFilters);
       save();


### PR DESCRIPTION
### Description
Load result filters calls a nonexistent function Misc.countAllKeys, causing it to error every time. I'm not completely certain what countAllKeys did but my best guess is that it counts the number of keys in a json object. I replaced the function call with code that counts the number of keys in the object, fixing the issue.