### PR TITLE
Clear sw-cache if localhost or new version

### DIFF
--- a/src/js/elements/new-version-notification.js
+++ b/src/js/elements/new-version-notification.js
@@ -15,7 +15,11 @@ export async function show(version) {
     setMemory(version);
     return;
   }
+  if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
+    caches.delete('sw-cache');
+  }
   if (memory === version) return;
+  caches.delete('sw-cache');
   Notifications.add(
     `Version ${version} has been released. Click to view the changelog.`,
     1,


### PR DESCRIPTION
### Description
Because `sw.js` doesn't check if it's cache is equal to the server's files, cache is not updated when a new version of the site's files are released. Fixed this by clearing cache on page load if working on localhost or 127.0.0.1 and clearing cache if a new version was released on Github.