### PR TITLE
Fix Contributing Guidelines Node JS Link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 - [Prerequisites](#prerequisites)
   - [Text Editor](#text-editor)
   - [Git ](#git)
-  - [NodeJS](#nodejs)
+  - [NodeJS and NPM](#nodejs-and-npm)
   - [Firebase](#firebase)
   - [Mongo Setup](#mongo-setup)
 - [Building and Running Monkeytype](#building-and-running-monkeytype)


### PR DESCRIPTION
Not something important just a little fix for the link the node js section in the contributing file since it wasn't working previously.