### PR TITLE
Fix bug that prevented sw cache from being deleted

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -281,8 +281,7 @@ task("updateSwCacheName", function () {
         `const staticCacheName = "sw-cache-${dateString}";`
       )
     )
-    .pipe(dest("./dist/"))
-    .pipe(dest("static/"));
+    .pipe(dest("./dist/"));
 });
 
 task(

--- a/static/sw.js
+++ b/static/sw.js
@@ -34,19 +34,20 @@ self.addEventListener("fetch", async (event) => {
     event.respondWith(fetch(event.request));
   } else {
     // Otherwise, assume host is serving a static file, check cache and add response to cache if not found
-    let cache = await caches.open(staticCacheName);
     event.respondWith(
-      cache.match(event.request).then(async (response) => {
-        // Check if request in cache
-        if (response) {
-          // if response was found in the cache, send from cache
-          return response;
-        } else {
-          // if response was not found in cache fetch from server, cache it and send it
-          response = await fetch(event.request);
-          cache.put(event.request.url, response.clone());
-          return response;
-        }
+      caches.open(staticCacheName).then((cache) => {
+        return cache.match(event.request).then(async (response) => {
+          // Check if request in cache
+          if (response) {
+            // if response was found in the cache, send from cache
+            return response;
+          } else {
+            // if response was not found in cache fetch from server, cache it and send it
+            response = await fetch(event.request);
+            cache.put(event.request.url, response.clone());
+            return response;
+          }
+        });
       })
     );
   }


### PR DESCRIPTION
### Description
Multiple things are occuring in this pr, all related to the service worker and caching system
*  Added `event.waitUntil(self.skipWaiting());` and `event.waitUntil(self.clients.claim());`
   * These functions stop old service workers and allow the new service worker to take control
     * https://stackoverflow.com/questions/41009167/what-is-the-use-of-self-clients-claim 
*  Placed delete caches inside of "activate" event.
   *  Caches should be removed and clients.claim() should be run when the sw is activated (first loaded)
* Open cache by name before checking and setting cache for better precision
* Removed "monkeytype.com" and "localhost:5000" from nocache list.
  * Now that sw.js is updated after each build and new files are requested, we don't have to request new ones if there was a bad file in an older version
* Stopped updating /static/sw.js on compile.
  * When gulp compile was run, the sw.js file in the static folder was updated. When watching files for updates in dev mode, updating static/sw.js causes the program to rebuild infinitely.
  * You could create a simple gulp task to copy sw from dist to static and add to build series if you think it's important to commit, but I don't think it's necessary