### PR TITLE
Caps lock

### DIFF
--- a/src/js/test/caps-warning.js
+++ b/src/js/test/caps-warning.js
@@ -16,9 +16,10 @@ let capsLockOn = false;
 
 $(document).keyup(function (event) {
   try {
-    if (!Config.capsLockWarning) return;
-
-    if (capsLockOn && event.originalEvent.which === 20) {
+    if (
+      (capsLockOn && event.originalEvent.which === 20) ||
+      !Config.capsLockWarning
+    ) {
       capsLockOn = false;
       hide();
       return;

--- a/src/js/test/caps-warning.js
+++ b/src/js/test/caps-warning.js
@@ -12,25 +12,21 @@ function hide() {
   }
 }
 
-$(document).keydown(function (event) {
-  try {
-    if (
-      Config.capsLockWarning &&
-      event.originalEvent.getModifierState("CapsLock")
-    ) {
-      show();
-    } else {
-      hide();
-    }
-  } catch {}
-});
+let capsLockOn = false;
 
 $(document).keyup(function (event) {
   try {
-    if (
-      Config.capsLockWarning &&
-      event.originalEvent.getModifierState("CapsLock")
-    ) {
+    if (!Config.capsLockWarning) return;
+
+    if (capsLockOn && event.originalEvent.which === 20) {
+      capsLockOn = false;
+      hide();
+      return;
+    }
+
+    capsLockOn = event.originalEvent.getModifierState("CapsLock");
+
+    if (capsLockOn) {
       show();
     } else {
       hide();


### PR DESCRIPTION
### Description

<!-- Please describe the change(s) made in your PR -->
When pressing the Caps Lock key, the warning gets immediately shown, but when pressing again, the warning only gets hidden after another key press. This PR aims at hiding the caps lock warning immediately after caps lock is deactivated.
