### PR TITLE
Added DMG theme

### DIFF
--- a/static/themes/_list.json
+++ b/static/themes/_list.json
@@ -708,5 +708,10 @@
     "name": "fleuriste",
     "bgColor": "#c6b294",
     "mainColor": "#405a52"
-   }
+  }
+  ,{
+    "name": "dmg",
+    "bgColor": "#dadbdc",
+    "mainColor": "#3846b1"
+	}
 ]

--- a/static/themes/dmg.css
+++ b/static/themes/dmg.css
@@ -1,0 +1,33 @@
+:root {
+    --bg-color: #dadbdc;
+    --main-color: #ae185e;
+    --caret-color: #384693;
+    --sub-color: #3846b1;
+    --text-color: #414141;
+    --error-color: #ae185e;
+    --error-extra-color: #93335c;
+    --colorful-error-color: #80a053;
+    --colorful-error-extra-color: #306230;
+}
+  
+#menu {
+  gap: 0.5rem;
+}
+
+#top.focus #menu .icon-button {
+  background: var(--bg-color);
+  size: 1rem;
+}
+#top.focus #menu .icon-button:nth-child(1) {
+  background: #e34c6c;
+}
+#top.focus #menu:before,
+#top.focus #menu:after {
+  background: var(--sub-color);
+}
+
+#menu .icon-button {
+  border-radius: 10rem !important;
+  color: var(--bg-color);
+  background: var(--main-color);
+}


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

<!-- Please describe the change(s) made in your PR -->

Added DMG theme. When typing is active, the menu buttons disappear to leave only one, the power indicator.

![1 - home](https://user-images.githubusercontent.com/86719130/152021253-e7a3d134-9b30-40d0-8acd-558a71c4a0fc.png)

Default color settings:
![2 - default](https://user-images.githubusercontent.com/86719130/152021351-3745f2aa-ca8b-418f-a76a-7049e029a503.png)


Colorful mode (green errors referencing the screen):
![3 - colorful](https://user-images.githubusercontent.com/86719130/152021376-f46fe6d7-7340-4742-b094-848d23c0f94a.png)


<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/Miodec/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
