### PR TITLE
command line addition

### DIFF
--- a/src/js/commandline.js
+++ b/src/js/commandline.js
@@ -131,7 +131,8 @@ function updateSuggested() {
           obj.alias !== undefined ? obj.alias.toLowerCase().match(re) : null;
         if (
           (res != null && res.length > 0) ||
-          (res2 != null && res2.length > 0)
+          (res2 != null && res2.length > 0) ) || 
+          obj.display.toLowerCase().includes(obj2)
         ) {
           foundcount++;
         } else {


### PR DESCRIPTION
Here is the addition of 1 line of code that will help people who type like not really good search something in command line. Like before when they were typing "ive" in the command line there were 0 results and now there are reults with words "live"(cause it contains "ive") inside them like "live WPM..." and so on
I guess that will not really abuse website cause I've tested this on my pc and it worked quite well