### PR TITLE
Fixed menu children properties

### DIFF
--- a/static/themes/fleuriste.css
+++ b/static/themes/fleuriste.css
@@ -10,11 +10,19 @@
   --colorful-error-extra-color: #bd4c4c;
 }
 
-#menu .icon-button:nth-child(1, 3, 5) {
+#menu .icon-button:nth-child(1) {
   background: #405a52;
 }
-#menu .icon-button:nth-child(2, 4) {
+#menu .icon-button:nth-child(3) {
+  background: #405a52;
+}
+#menu .icon-button:nth-child(5) {
+  background: #405a52;
+}
+#menu .icon-button:nth-child(2) {
   background: #64374d;
 }
-
+#menu .icon-button:nth-child(4) {
+  background: #64374d;
+}
 


### PR DESCRIPTION

##  PR solves:

This aims to fix the backgrounds of menu children. They should be differing in background color however because the css is incorrect it isn't working completely correctly.

