### PR TITLE
feat(cmd): Add command to choose a quote

### DIFF
--- a/frontend/src/scripts/elements/commandline-lists.ts
+++ b/frontend/src/scripts/elements/commandline-lists.ts
@@ -3183,7 +3183,7 @@ export const defaultCommands: MonkeyTypes.CommandsGroup = {
     {
       id: "quoteChoice",
       display: "Choose Quote...",
-      icon: "fa-bars",
+      icon: "fa-align-left",
       subgroup: quoteChoice,
     },
   ],

--- a/frontend/src/scripts/elements/commandline-lists.ts
+++ b/frontend/src/scripts/elements/commandline-lists.ts
@@ -2449,6 +2449,39 @@ const commandsMonkeyPowerLevel: MonkeyTypes.CommandsGroup = {
   ],
 };
 
+export const quoteChoice: MonkeyTypes.CommandsGroup = {
+  title: "Quote...",
+  list: [
+    {
+      id: "fatalerror",
+      display: "Loading quotes...",
+    },
+  ],
+};
+
+Misc.getQuotes(Config.language).then((result) => {
+  quoteChoice.list = result.quotes.map((quote) => {
+    const quoteId = quote.id;
+    const commandId = `quoteChoice-${quoteId}`;
+
+    const quoteText = quote.text;
+    const quoteSource = quote.source;
+    const commandDisplay = `${quoteText} [${quoteSource}]`;
+
+    const quoteWords = quoteText.split(" ");
+
+    return {
+      id: commandId,
+      display: commandDisplay,
+      exec: (): void => {
+        UpdateConfig.setMode("custom");
+        CustomText.setText(quoteWords);
+        TestLogic.restart();
+      },
+    } as MonkeyTypes.Command;
+  });
+});
+
 export const defaultCommands: MonkeyTypes.CommandsGroup = {
   title: "",
   list: [
@@ -3146,6 +3179,12 @@ export const defaultCommands: MonkeyTypes.CommandsGroup = {
       exec: async (): Promise<void> => {
         alert(await caches.keys());
       },
+    },
+    {
+      id: "chooseQuote",
+      display: "Choose Quote...",
+      icon: "fa-bars",
+      subgroup: quoteChoice,
     },
   ],
 };

--- a/frontend/src/scripts/elements/commandline-lists.ts
+++ b/frontend/src/scripts/elements/commandline-lists.ts
@@ -3181,7 +3181,7 @@ export const defaultCommands: MonkeyTypes.CommandsGroup = {
       },
     },
     {
-      id: "chooseQuote",
+      id: "quoteChoice",
       display: "Choose Quote...",
       icon: "fa-bars",
       subgroup: quoteChoice,


### PR DESCRIPTION
### Description

This PR aims to add a command to the commandline that allows the user to pick a specific quote. When a quote is selected, the mode will be switched to 'custom' and the custom text will be set to the text of the respective quote.

The currently selected language will be considered in the options the user is given for selecting a quote in the submenu.


### Known Problems

- The options are only adapted to the language the first time the site loads
  (-> doesn't reflect language changes without reloading)
  **Requires generating the options before the submenu is opened - is that even currently possible in the command line? Also performance?**
- The site seems to become "laggy" the 2nd time a quote is selected?
- Whatever is happening here in the last element of the list
  ![image](https://user-images.githubusercontent.com/56218513/154781022-532911a1-319a-450c-970f-66206bc042f9.png)
  (Potentially the command line understandably just not being made for this many options?)



### More Information

When the first "known problem" is fixed, I assume that the same solution could be used to also consider the currently selected quote length when generating the quote options for the submenu.