### PR TITLE
display 0 if the time typing is NaN, closes #2567

### DIFF
--- a/frontend/src/scripts/account/all-time-stats.ts
+++ b/frontend/src/scripts/account/all-time-stats.ts
@@ -14,9 +14,10 @@ export function update(): void {
     // let th = Math.floor(DB.getSnapshot().globalStats.time / 3600);
     // let tm = Math.floor((DB.getSnapshot().globalStats.time % 3600) / 60);
     // let ts = Math.floor((DB.getSnapshot().globalStats.time % 3600) % 60);
+    const x: number = snapshot.globalStats.time as number; 
     $(".pageAccount .globalTimeTyping .val").text(
       Misc.secondsToString(
-        Math.round(snapshot.globalStats.time as number),
+        !isNaN(x)) ? Math.round(x) : 0,
         true,
         true
       )

--- a/frontend/src/scripts/account/all-time-stats.ts
+++ b/frontend/src/scripts/account/all-time-stats.ts
@@ -14,14 +14,14 @@ export function update(): void {
     // let th = Math.floor(DB.getSnapshot().globalStats.time / 3600);
     // let tm = Math.floor((DB.getSnapshot().globalStats.time % 3600) / 60);
     // let ts = Math.floor((DB.getSnapshot().globalStats.time % 3600) % 60);
-    const x: number = snapshot.globalStats.time as number; 
-    $(".pageAccount .globalTimeTyping .val").text(
-      Misc.secondsToString(
-        !isNaN(x)) ? Math.round(x) : 0,
-        true,
-        true
-      )
-    );
+    const seconds = snapshot?.globalStats?.time ?? 0;
+    let string = "";
+    if (seconds === 0) {
+      string = "-";
+    } else {
+      string = Misc.secondsToString(seconds, true, true);
+    }
+    $(".pageAccount .globalTimeTyping .val").text(string);
   }
 
   if (snapshot.globalStats !== undefined) {


### PR DESCRIPTION
### Description

<!-- Please describe the change(s) made in your PR -->
When creating a new account, the total time typing shows `NaN:NaN:NaN`. This PR _**should**_ fix it. See https://github.com/Miodec/monkeytype/issues/2567

Closes #2567

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/Miodec/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
