### PR TITLE
Fix layoutfluid timer warnings

### DIFF
--- a/frontend/src/scripts/test/test-timer.ts
+++ b/frontend/src/scripts/test/test-timer.ts
@@ -87,35 +87,28 @@ function layoutfluid(): void {
     const layouts = Config.customLayoutfluid
       ? Config.customLayoutfluid.split("#")
       : ["qwerty", "dvorak", "colemak"];
-    // console.log(Config.customLayoutfluid);
-    // console.log(layouts);
-    const numLayouts = layouts.length;
-    let index = 0;
-    index = Math.floor(Time.get() / (Config.time / numLayouts));
+    const switchTime = Config.time / layouts.length;
+    const time = Time.get();
+    const index = Math.floor(time / switchTime);
+    const layout = layouts[index];
+    const flooredSwitchTimes = [];
 
-    if (
-      Time.get() == Math.floor(Config.time / numLayouts) - 3 ||
-      Time.get() == (Config.time / numLayouts) * 2 - 3
-    ) {
+    for (let i = 1; i < layouts.length; i++) {
+      flooredSwitchTimes.push(Math.floor(switchTime * i));
+    }
+
+    if (flooredSwitchTimes.includes(time + 3)) {
       Notifications.add("3", 0, 1);
-    }
-    if (
-      Time.get() == Math.floor(Config.time / numLayouts) - 2 ||
-      Time.get() == Math.floor(Config.time / numLayouts) * 2 - 2
-    ) {
+    } else if (flooredSwitchTimes.includes(time + 2)) {
       Notifications.add("2", 0, 1);
-    }
-    if (
-      Time.get() == Math.floor(Config.time / numLayouts) - 1 ||
-      Time.get() == Math.floor(Config.time / numLayouts) * 2 - 1
-    ) {
+    } else if (flooredSwitchTimes.includes(time + 1)) {
       Notifications.add("1", 0, 1);
     }
 
-    if (Config.layout !== layouts[index] && layouts[index] !== undefined) {
-      Notifications.add(`--- !!! ${layouts[index]} !!! ---`, 0);
-      UpdateConfig.setLayout(layouts[index], true);
-      UpdateConfig.setKeymapLayout(layouts[index], true);
+    if (Config.layout !== layout && layout !== undefined) {
+      Notifications.add(`--- !!! ${layout} !!! ---`, 0);
+      UpdateConfig.setLayout(layout, true);
+      UpdateConfig.setKeymapLayout(layout, true);
     }
   }
   if (timerDebug) console.timeEnd("layoutfluid");


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

<!-- Please describe the change(s) made in your PR -->

Fixed the layoutfluid timer warnings so that it happens on all amounts of layouts and so that the countdown and switch are accurate.

Closes #

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/Miodec/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
