### PR TITLE
Keep funbox annotation line transparent

### DIFF
--- a/frontend/src/scripts/controllers/chart-controller.ts
+++ b/frontend/src/scripts/controllers/chart-controller.ts
@@ -770,7 +770,9 @@ export async function updateColors<
     (chart.options as PluginChartOptions<TType>).plugins.annotation
       .annotations as AnnotationOptions<"line">[]
   ).forEach((annotation) => {
-    annotation.borderColor = subcolor;
+    if (annotation.id !== "funbox-label") {
+      annotation.borderColor = subcolor;
+    }
     (annotation.label as LabelOptions).backgroundColor = subcolor;
     (annotation.label as LabelOptions).color = bgcolor;
   });


### PR DESCRIPTION
### Description

Keeps the line that the funbox label annotation sits on transparent.