### PR TITLE
Fix links and styles in some pages

### DIFF
--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -17,7 +17,7 @@ Once you have forked the repository you can now add your language. Create a new 
 
 The contents of the file should be as follows:
 
-```
+```json
 {
   "name": "language",
   "leftToRight": true,
@@ -34,7 +34,7 @@ It is recommended that you familiarize yourselves with JSON before adding a lang
 
 In addition to the language file, you need to add your language to the `_groups.json` and `_list.json` files in the same directory. Add the name of the language to the `_groups.json` file like so:
 
-```
+```json
 {
   "name": "spanish",
   "languages": ["spanish", "spanish_1k", "spanish_10k"]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ On the [Monkeytype Discord server](https://www.discord.gg/monkeytype), we added 
 
 # Bug report or Feature request
 
-If you encounter a bug or have a feature request, [send us an email](jack@monkeytype.com), [create an issue](https://github.com/Miodec/monkeytype/issues), [create a discussion thread](https://github.com/Miodec/monkeytype/discussions), or [join the Discord server](https://www.discord.gg/monkeytype).
+If you encounter a bug or have a feature request, [send us an email](mailto:jack@monkeytype.com), [create an issue](https://github.com/Miodec/monkeytype/issues), [create a discussion thread](https://github.com/Miodec/monkeytype/discussions), or [join the Discord server](https://www.discord.gg/monkeytype).
 
 # Want to Contribute?
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ We take the security and integrity of Monkeytype very seriously. If you have fou
 
 ### Reporting a Vulnerability
 
-For vulnerabilities that impact the confidentiality, integrity, and availability of Monkeytype services, please send your disclosure via (1) [email](jack@monkeytype.com), or (2) private Discord chat to Miodec (Miodec#1512). For non-security related platform bugs, follow the bug submission [guidelines](https://github.com/Miodec/monkeytype#bug-report-or-feature-request). Include as much detail as possible to ensure reproducibility. At a minimum, vulnerability disclosures should include:
+For vulnerabilities that impact the confidentiality, integrity, and availability of Monkeytype services, please send your disclosure via (1) [email](mailto:jack@monkeytype.com), or (2) private Discord chat to Miodec (Miodec#1512). For non-security related platform bugs, follow the bug submission [guidelines](https://github.com/Miodec/monkeytype#bug-report-or-feature-request). Include as much detail as possible to ensure reproducibility. At a minimum, vulnerability disclosures should include:
 
 - Vulnerability Description
 - Proof of Concept

--- a/THEMES.md
+++ b/THEMES.md
@@ -18,7 +18,7 @@ After you have forked the repository you can now add your theme. Create a CSS fi
 
 Then add this code to your file:
 
-```
+```css
 :root {
     --bg-color: #ffffff;
     --main-color: #ffffff;
@@ -37,7 +37,7 @@ Here is an image showing what all the properties correspond to:
 
 Change the corresponding hex codes to create your theme. Then, go to `./frontend/static/themes/_list.json` and add the following code to the very end of the file (inside the square brackets):
 
-```
+```json
 ,{
     "name": "theme_name",
     "bgColor": "#ffffff",

--- a/frontend/static/email-handler.html
+++ b/frontend/static/email-handler.html
@@ -6,6 +6,7 @@
     <title>Email Handler | Monkeytype</title>
     <!-- <link rel="stylesheet" href="css/fa.css" /> -->
     <link rel="stylesheet" href="css/balloon.css" />
+    <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="themes/serika_dark.css" id="currentTheme" />
     <link rel="stylesheet" href="" id="funBoxTheme" />
     <link id="favicon" rel="shortcut icon" href="images/fav.png" />

--- a/frontend/static/privacy-policy.html
+++ b/frontend/static/privacy-policy.html
@@ -6,6 +6,7 @@
     <title>Privacy Policy | Monkeytype</title>
     <!-- <link rel="stylesheet" href="css/fa.css" /> -->
     <link rel="stylesheet" href="css/balloon.css" />
+    <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="themes/serika_dark.css" id="currentTheme" />
     <link rel="stylesheet" href="" id="funBoxTheme" />
     <link id="favicon" rel="shortcut icon" href="images/fav.png" />

--- a/frontend/static/security-policy.html
+++ b/frontend/static/security-policy.html
@@ -6,6 +6,7 @@
     <title>Security Policy | Monkeytype</title>
     <!-- <link rel="stylesheet" href="css/fa.css" /> -->
     <link rel="stylesheet" href="css/balloon.css" />
+    <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="themes/serika_dark.css" id="currentTheme" />
     <link rel="stylesheet" href="" id="funBoxTheme" />
     <link id="favicon" rel="shortcut icon" href="images/fav.png" />

--- a/frontend/static/terms-of-service.html
+++ b/frontend/static/terms-of-service.html
@@ -6,6 +6,7 @@
     <title>Terms of Service | Monkeytype</title>
     <!-- <link rel="stylesheet" href="css/fa.css" /> -->
     <link rel="stylesheet" href="css/balloon.css" />
+    <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="themes/serika_dark.css" id="currentTheme" />
     <link rel="stylesheet" href="" id="funBoxTheme" />
     <link id="favicon" rel="shortcut icon" href="images/fav.png" />


### PR DESCRIPTION
- [x] Fixed email links by adding the `mailto:` prefix.
- [x] Added language name to some blocks of code.
- [x] Added the missing style tag in `head` of some pages (see the following screenshots for examples):

Without the style.css file:
![Without the style.css file](https://user-images.githubusercontent.com/18559798/161720825-062752ab-150c-4ab4-8c6a-04c268d88f09.png)


With the style.css file (fixed):
![With the style.css file](https://user-images.githubusercontent.com/18559798/161720710-a040819e-1fb4-4f44-85ad-c0a9092a2c11.png)

(just, I didn't compile, but I think it's good.)