### PR TITLE
Add layout - turkish q

### DIFF
--- a/frontend/static/layouts/_list.json
+++ b/frontend/static/layouts/_list.json
@@ -131,6 +131,17 @@
       "row5": [" "]
     }
   },
+  "turkish_q": {
+    "keymapShowTopRow": false,
+    "type": "ansi",
+    "keys": {
+      "row1": ["\"é", "1!", "2'", "3^", "4+", "5%", "6&", "7/", "8(", "9)", "0=", "*?", "-_"],
+      "row2": ["qQ", "wW", "eE", "rR", "tT", "yY", "uU", "ıI", "oO", "pP", "ğĞ", "üÜ", ",;"],
+      "row3": ["aA", "sS", "dD", "fF", "gG", "hH", "jJ", "kK", "lL", "şŞ", "iİ"],
+      "row4": ["zZ", "xX", "cC", "vV", "bB", "nN", "mM", "öÖ", "çÇ", ".:"],
+      "row5": [" "]
+    }
+  },
   "turkish_f": {
     "keymapShowTopRow": false,
     "type": "ansi",


### PR DESCRIPTION
### Description
Layout emulator had the turkish f layout but not turkish q, turkish q is basically qwerty but right hand changed so
you can enter `ç`, `ğ`, `ı`, `ö`, `ş` and `ü` without using dead keys, also with [two i's](https://en.wikipedia.org/wiki/Dotted_and_dotless_I)