### PR TITLE
Added themes for GNOME Dark and GNOME Light (Based on GNOME Terminal)

### DIFF
--- a/frontend/static/themes/_list.json
+++ b/frontend/static/themes/_list.json
@@ -743,5 +743,15 @@
     "name": "mexican",
     "bgColor": "#cec176",
     "mainColor": "#ffffff"
+  },
+  {
+    "name": "gnome_dark",
+    "bgColor": "#171421",
+    "mainColor": "#D0CFCC"
+  },
+  {
+    "name": "gnome_light",
+    "bgColor": "#FFFFFF",
+    "mainColor": "#D0CFCC"
   }
 ]

--- a/frontend/static/themes/gnome_dark.css
+++ b/frontend/static/themes/gnome_dark.css
@@ -1,0 +1,12 @@
+:root {
+  --bg-color: #171421;
+  --main-color: #D0CFCC;
+  --caret-color: #2A7BDE;
+  --sub-color: #2A7BDE;
+  --sub-alt-color: #5E5C64;
+  --text-color: #D0CFCC;
+  --error-color: #C01C28;
+  --error-extra-color: #C01C28;
+  --colorful-error-color: #C01C28;
+  --colorful-error-extra-color: #C01C28;
+}

--- a/frontend/static/themes/gnome_light.css
+++ b/frontend/static/themes/gnome_light.css
@@ -1,0 +1,12 @@
+:root {
+  --bg-color: #FFFFFF;
+  --main-color: #D0CFCC;
+  --caret-color: #2A7BDE;
+  --sub-color: #2A7BDE;
+  --sub-alt-color: #5E5C64;
+  --text-color: #171421;
+  --error-color: #C01C28;
+  --error-extra-color: #C01C28;
+  --colorful-error-color: #C01C28;
+  --colorful-error-extra-color: #C01C28;
+}


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

<!-- Please describe the change(s) made in your PR -->

I have added themes for the GNOME light and dark color schemes. These are based on the GNOME terminal's default color schemes.

### Screenshots
GNOME Light
![GNOME Light](https://raw.githubusercontent.com/owengaspard/scr/main/Screen%20Shot%202022-04-13%20at%201.46.36%20AM.png)
GNOME Dark
![GNOME Dark](https://raw.githubusercontent.com/owengaspard/scr/main/Screen%20Shot%202022-04-13%20at%201.46.59%20AM.png)

Closes #

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/Miodec/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
