### PR TITLE
Fix spacing on about page

### DIFF
--- a/frontend/static/html/pages/about.html
+++ b/frontend/static/html/pages/about.html
@@ -187,9 +187,8 @@
         href="https://www.reddit.com/user/montydrei"
         target="_blank"
         rel="noreferrer"
+        >Montydrei</a
       >
-        Montydrei
-      </a>
       for the name suggestion
     </p>
     <p>
@@ -197,9 +196,8 @@
         href="https://www.reddit.com/r/MechanicalKeyboards/comments/gc6wx3/experimenting_with_a_completely_new_type_of/"
         target="_blank"
         rel="noreferrer"
+        >Everyone</a
       >
-        Everyone
-      </a>
       who provided valuable feedback on the original reddit post for the
       prototype of this website
     </p>
@@ -212,9 +210,8 @@
         href="https://github.com/Miodec/monkeytype/graphs/contributors"
         target="_blank"
         rel="noreferrer"
+        >Contributors</a
       >
-        Contributors
-      </a>
       on GitHub that have helped with implementing various features, adding
       themes and more
     </p>


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

<!-- Please describe the change(s) made in your PR -->
I've fixed the spacing between the people who helped and what they helped with on the about page. The change just concerns how whitespace is handled in html. If you format it with an automatic tool, there's probably a way to remove spaces from inside the `a` tags so that the spacing is correct.

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/Miodec/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
