### PR TITLE
Fix spacing in Security Policy

### DIFF
--- a/frontend/static/security-policy.html
+++ b/frontend/static/security-policy.html
@@ -148,7 +148,7 @@
           <a href="https://www.discord.gg/monkeytype">
             Monkeytype Discord server in the #development channel
           </a>
-          and he can discuss the situation with you further in private. For
+           and he can discuss the situation with you further in private. For
           non-security related platform bugs, follow the bug submission
           <a
             href="https://github.com/Miodec/monkeytype#bug-report-or-feature-request"


### PR DESCRIPTION
### Description

- Fix the spacing in Security Policy in the header "How to Disclose a Vulnerability"
- As you can see in the screenshot after the long link, there is a space missing
![image](https://user-images.githubusercontent.com/67599521/164322454-4cf24b92-296b-4080-b96c-3cca1f95f5e6.png)

- But I haven't tested it by recompiling it, that's why I'm not sure, if it fixes the spacing

- Note: Maybe "Disclose" should also be lowercase

