### PR TITLE
Fixes Javascript typo (#2884)

### DIFF
--- a/frontend/static/languages/code_javascript.json
+++ b/frontend/static/languages/code_javascript.json
@@ -83,7 +83,7 @@
     "nodeName",
     "nodeType",
     "onclick",
-    "ondbclick",
+    "ondblclick",
     "onmousedown",
     "onmouseenter",
     "onmouseup",


### PR DESCRIPTION
### Description

As a frequent user of the Javascript Code prompt, this is just a small nitpick that's been bugging me (pun intended 🙂) for a while. There is no `ondbclick` method or property in the Javascript language. This PR simply fixes the typo in the `code_javascript.json` file to change `ondbclick` to the corrected `ondblclick`.

MDN Link:
https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/ondblclick

I checked `code_javascript_1k.json` to make sure the typo didn't occur in that file, and confirmed that `ondbclick` only exists in `code_javascript.json`.

Love this product and happy to help in any way I can. Please let me know if I missed anything!

Closes #2884 