### PR TITLE
Defaults analytics to be unchecked

### DIFF
--- a/frontend/static/html/popups.html
+++ b/frontend/static/html/popups.html
@@ -56,7 +56,7 @@
             We use Google Analytics cookies to check how users interact with our
             website and use this data to improve our site design.
           </div>
-          <input type="checkbox" checked />
+          <input type="checkbox" />
           <div class="customTextCheckbox">
             <div class="check">
               <i class="fas fa-fw fa-check"></i>


### PR DESCRIPTION
To conform with GDPR, analytics **MUST** be opt-in, and disabled by default.

For reference, in the UK's guidance on GDPR compliance:

> Consent requires a positive opt-in. Don’t use pre-ticked boxes or any other method of default consent.

https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/?template=pdf&patch=97#link14

So I removed the tag that makes the analytics consent checkbox checked by default.

I was quite shocked that this free software project was asking me for consent to analytics. I'm glad I was informed, but noticed this mistake immediately when I went to reject them.
