### PR TITLE
fix: leaderboard keeping pagination after switching language (@fehmer)

### DIFF
--- a/frontend/src/ts/pages/leaderboards.ts
+++ b/frontend/src/ts/pages/leaderboards.ts
@@ -1235,6 +1235,7 @@ $(".page.pageLeaderboards .buttonGroup.secondary").on(
     } else if (language !== undefined && state.type === "daily") {
       if (state.language === language) return;
       state.language = language;
+      state.page = 0;
     } else {
       return;
     }


### PR DESCRIPTION
Fixes daily leaderboard staying on a selected page after switching languages. If the new language has less pages the user was stuck as none of the navigation buttons were active.

The easy fix is to always start at the first page after switching languages. We do the same when switching leaderboards (e.g. daily to xp weekly)