### PR TITLE
fix(focus mode): remove cursor when in hovering over links and buttons (@jaydent, @miodec)

### DIFF
--- a/frontend/src/ts/test/focus.ts
+++ b/frontend/src/ts/test/focus.ts
@@ -14,7 +14,9 @@ export function set(foc: boolean, withCursor = false): void {
     Caret.stopAnimation();
     $("header").addClass("focus");
     $("footer").addClass("focus");
-    if (!withCursor) $("*").css("cursor", "none");
+    if (!withCursor) $("body").css("cursor", "none");
+    $("button").css("cursor", "none");
+    $("a").css("cursor", "none");
     $("main").addClass("focus");
     $("#bannerCenter").addClass("focus");
     $("#notificationCenter").addClass("focus");
@@ -32,7 +34,9 @@ export function set(foc: boolean, withCursor = false): void {
     Caret.startAnimation();
     $("header").removeClass("focus");
     $("footer").removeClass("focus");
-    $("*").css("cursor", "default");
+    $("body").css("cursor", "default");
+    $("button").css("cursor", "default");
+    $("a").css("cursor", "default");
     $("main").removeClass("focus");
     $("#bannerCenter").removeClass("focus");
     $("#notificationCenter").removeClass("focus");


### PR DESCRIPTION
### Description

Changed `("body").css("cursor", "none")` to `("*").css("cursor", "none")`  to fix cursor staying when in focus mode.

Closes #6644
