### PR TITLE
impr(modes-notice): make average wpm and accuracy show decimal places when appropriate (@blru)

### DIFF
--- a/frontend/src/ts/elements/modes-notice.ts
+++ b/frontend/src/ts/elements/modes-notice.ts
@@ -26,6 +26,7 @@ ConfigEvent.subscribe((eventKey) => {
     "typingSpeedUnit",
     "quickRestart",
     "customPolyglot",
+    "alwaysShowDecimalPlaces",
   ];
   if (configKeys.includes(eventKey)) {
     void update();
@@ -170,14 +171,11 @@ export async function update(): Promise<void> {
 
     if (isAuthenticated() && avgWPM > 0) {
       const avgWPMText = ["speed", "both"].includes(Config.showAverage)
-        ? Format.typingSpeed(avgWPM, {
-            suffix: ` ${Config.typingSpeedUnit}`,
-            showDecimalPlaces: false,
-          })
+        ? Format.typingSpeed(avgWPM, { suffix: ` ${Config.typingSpeedUnit}` })
         : "";
 
       const avgAccText = ["acc", "both"].includes(Config.showAverage)
-        ? Format.accuracy(avgAcc, { suffix: " acc", showDecimalPlaces: false })
+        ? Format.accuracy(avgAcc, { suffix: " acc" })
         : "";
 
       const text = `${avgWPMText} ${avgAccText}`.trim();


### PR DESCRIPTION
### Description

Makes it so that the average wpm and accuracy indicators shown above the typing area have their decimals visible when the `alwaysShowDecimalPlaces` config option is set to true.

### Checks

- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.