### PR TITLE
fix: Misspelt items in League of Legends language (@kiriDevs)

### DIFF
--- a/frontend/static/languages/league_of_legends.json
+++ b/frontend/static/languages/league_of_legends.json
@@ -258,7 +258,7 @@
     "Ocean Dragon",
     "Olaf",
     "Opportunity",
-    "Oracles Lens",
+    "Oracle Lens",
     "Orianna",
     "Ornn",
     "Outer Towers",


### PR DESCRIPTION
The League of Legends language listed:
- Symb**oi**tic Soles
- Mik**ea**l's Crucible
- Wi**tt**'s End
- Oracle**s** Lens

However, the items are called:
- Symb**io**tic Soles
- Mik**ae**l's Crucible
- Wi**t**'s End
- Oracle Lens

https://wiki.leagueoflegends.com/en-us/Symbiotic_Soles
https://wiki.leagueoflegends.com/en-us/Mikael%27s_Crucible
https://wiki.leagueoflegends.com/en-us/Wit%27s_End
https://wiki.leagueoflegends.com/en-us/Oracle_Lens