### PR TITLE
fix(config): numbers and punctuation always reset to false (@fehmer)

### DIFF
--- a/frontend/__tests__/root/config.spec.ts
+++ b/frontend/__tests__/root/config.spec.ts
@@ -1163,9 +1163,20 @@ describe("Config", () => {
         expected: Partial<ConfigType>;
       }[] = [
         {
-          display: "quote length shouldnt override mode",
-          value: { quoteLength: [0], mode: "time" },
-          expected: { quoteLength: [0], mode: "time" },
+          display:
+            "quote length shouldnt override mode, punctuation and numbers",
+          value: {
+            punctuation: true,
+            numbers: true,
+            quoteLength: [0],
+            mode: "time",
+          },
+          expected: {
+            punctuation: true,
+            numbers: true,
+            quoteLength: [0],
+            mode: "time",
+          },
         },
       ];
 

--- a/frontend/src/ts/config.ts
+++ b/frontend/src/ts/config.ts
@@ -810,12 +810,12 @@ const lastConfigsToApply: Set<keyof Config> = new Set([
   "minAcc",
   "minBurst",
   "paceCaret",
-  "punctuation",
-  "numbers",
-  "quoteLength",
-  "time",
+  "quoteLength", //quote length sets mode,
   "words",
-  "mode",
+  "mode", // mode sets punctuation and numbers
+  "numbers",
+  "punctuation",
+  "time",
   "funbox",
 ]);
 


### PR DESCRIPTION
fixes #6826