### PR TITLE
fix(buildInputCommand): Custom settings not being saved properly when applied through commandline (@raaid3)

### DIFF
--- a/frontend/src/ts/commandline/util.ts
+++ b/frontend/src/ts/commandline/util.ts
@@ -68,6 +68,7 @@ function _buildCommandForConfigKey<
     const inputProps = commandMeta.input;
 
     const inputCommand = buildInputCommand({
+      rootKey: key,
       key: "secondKey" in inputProps ? inputProps.secondKey : key,
       isPartOfSubgruop: "subgroup" in commandMeta,
       inputProps: inputProps as InputProps<keyof ConfigSchemas.Config>,
@@ -200,12 +201,14 @@ function buildSubgroupCommand<K extends keyof ConfigSchemas.Config>(
 }
 
 function buildInputCommand<K extends keyof ConfigSchemas.Config>({
+  rootKey,
   key,
   isPartOfSubgruop,
   inputProps,
   configMeta,
   schema,
 }: {
+  rootKey: keyof ConfigSchemas.Config;
   key: K;
   isPartOfSubgruop: boolean;
   inputProps?: InputProps<K>;
@@ -236,6 +239,13 @@ function buildInputCommand<K extends keyof ConfigSchemas.Config>({
     //@ts-expect-error this is fine
     exec: ({ input }): void => {
       if (input === undefined) return;
+      if (
+        inputProps !== undefined &&
+        "secondKey" in inputProps &&
+        inputProps.configValue !== undefined
+      ) {
+        genericSet(rootKey, inputProps.configValue);
+      }
       genericSet(key, input as ConfigSchemas.Config[K]);
       inputProps?.afterExec?.(input as ConfigSchemas.Config[K]);
     },


### PR DESCRIPTION
### Description

When applying custom settings like paceCaretCustomSpeed and minWpmCustomSpeed, only the custom values are saved to the DB, but not the "modes" like `{paceCaret: "custom"}` or `{minWpm: "custom"}`

So the config being saved when applying the setting would just be: `{paceCaretCustomSpeed: 120}` for example, instead of `{paceCaretCustomSpeed: 120, paceCaret: "custom"}`. This means a simple reload would would fetch the configValue set before this instead of "custom".

https://github.com/user-attachments/assets/44bb64e2-c99b-460a-b0f4-8de6389c0077

To fix this, I add an argument "rootKey" (e.g. paceCaret) to `buildInputCommand` in addition to alread accepting the secondaryKey (e.g. paceCaretCustomSpeed). This way, `genericSet` can be called on the rootKey as well to set it to "custom".