### PR TITLE
fix(testActivity): timezone edge case causing tests to appear on incorrect day (@fehmer)

### DIFF
--- a/frontend/src/ts/elements/test-activity-calendar.ts
+++ b/frontend/src/ts/elements/test-activity-calendar.ts
@@ -54,7 +54,7 @@ export class TestActivityCalendar implements TestActivityCalendar {
   }
 
   protected getInterval(lastDay: Date, fullYear = false): Interval {
-    const end = fullYear ? endOfYear(lastDay) : new Date();
+    const end = fullYear ? endOfYear(lastDay) : new UTCDateMini();
     let start = startOfYear(lastDay);
     if (!fullYear) {
       //show the last 52 weeks. Not using one year to avoid the graph to show 54 weeks


### PR DESCRIPTION
steps to reproduce:
- set the browsers timezone with minus offset that is greater then the current time utc (so new Date() will land on yesterday)
- the easiest way to do this is to open dev tools, sensors and add a location with timezone `Pacific/Pago_Pago` which is UTC-11
- have a user with no activity for  at least  the last two days  (utc)
- remember the last activity in the chart,  e,g, August 8th has five tests
- the last day on the chart is yesterday
- do a test
- graph now shows one activity for yesterday
- the remembered last activity is now shifted to e.g. August 7th with five tests

fixed behaviour:
- same setup as before
- remember the last activity in the chart,  e,g, August 8th has five tests
- FIXED: the last day on the chart is today (in utc, so tomorrow in the users timezone)
- do a  test
- FIXED graph shows one activity for today (in utc)
- FIXED the remembered last activity is still on August 8th with five tests