### PR TITLE
fix: wrapper height not updated when tape is turned off mid-test (@nadalaba)

### DIFF
--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -616,13 +616,15 @@ export function updateWordsWrapperHeight(force = false): void {
   } else {
     if (Config.tapeMode === "off") {
       //tape off, showAllLines off, non-zen mode
+      const wordElements =
+        document.querySelectorAll<HTMLElement>("#words .word");
       let lines = 0;
       let lastTop = 0;
       let wordIndex = 0;
       let wrapperHeight = 0;
 
       while (lines < 3) {
-        const word = getWordElement(wordIndex);
+        const word = wordElements[wordIndex];
         if (!word) break;
         const top = word.offsetTop;
         if (top > lastTop) {


### PR DESCRIPTION
- this happens if words were removed (due to overflowing the wrapper) before turning the tape off

https://github.com/user-attachments/assets/97be5efb-4a37-46b7-baa2-dd482e84a43c

this is a regression introduced in #6932