### PR TITLE
fix: Fix invalid preset name (@Leonabcd123)

### DIFF
--- a/frontend/src/ts/modals/edit-preset.ts
+++ b/frontend/src/ts/modals/edit-preset.ts
@@ -93,6 +93,7 @@ export function show(action: string, id?: string, name?: string): void {
         id !== undefined &&
         name !== undefined
       ) {
+        presetNameEl?.setValue(name);
         $("#editPresetModal .modal").attr("data-action", "remove");
         $("#editPresetModal .modal").attr("data-preset-id", id);
         $("#editPresetModal .modal .popupTitle").html("Delete preset");


### PR DESCRIPTION
### Description

Updated input element to use the valid saved name instead of the current, potentially invalid one.

Closes #7064 
