### PR TITLE
fix(test): don't ignore caps lock in layout emulator (@fehmer)

### DIFF
--- a/frontend/src/ts/test/layout-emulator.ts
+++ b/frontend/src/ts/test/layout-emulator.ts
@@ -20,7 +20,7 @@ export async function getCharFromEvent(
     let isCapitalized = event.shiftKey;
     const altGrIndex = isAltGrPressed && keyVariants.length > 2 ? 2 : 0;
     const isNotPunctuation = !isPunctuationPattern.test(
-      keyVariants.slice(altGrIndex, altGrIndex + 2).join()
+      keyVariants.slice(altGrIndex, altGrIndex + 2).join("")
     );
     if (capsState && isNotPunctuation) {
       isCapitalized = !event.shiftKey;


### PR DESCRIPTION
With layout emulation set to qwerty and caps-lock enabled keypresses are registered as lowercase.
