### PR TITLE
impr(input-history): Change style for incomplete last word in input history (@Leonabcd123)

### DIFF
--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -1306,20 +1306,17 @@ async function loadWordsHistory(): Promise<boolean> {
 
       const isIncorrectWord = input !== word;
       const isLastWord = i === inputHistoryLength - 1;
-      const isTestTimed =
+      const isTimedTest =
         Config.mode === "time" ||
         (Config.mode === "custom" && CustomText.getLimitMode() === "time") ||
         (Config.mode === "custom" && CustomText.getLimitValue() === 0);
-      const isZenMode = Config.mode === "zen";
       const isPartiallyCorrect = word.substring(0, input.length) === input;
 
-      const errorClass = isZenMode
-        ? ""
-        : isIncorrectWord
-          ? isLastWord && isTestTimed && isPartiallyCorrect
-            ? ""
-            : "error"
-          : "";
+      const shouldShowError =
+        Config.mode !== "zen" &&
+        !(isLastWord && isTimedTest && isPartiallyCorrect);
+
+      const errorClass = isIncorrectWord && shouldShowError ? "error" : "";
 
       if (corrected !== undefined && corrected !== "") {
         const correctedChar = !containsKorean


### PR DESCRIPTION
### Description

Added a new style named "incomplete" that mirrors the error style, but uses yellow for the color. Words are marked in this style when they don't match the correct word exactly, but share the same prefix.

Implements #6690 
