### PR TITLE
impr(practice-words): Add option to practice missed and slow words from commandline (@Leonabcd123)

### DIFF
--- a/frontend/src/ts/commandline/lists/result-screen.ts
+++ b/frontend/src/ts/commandline/lists/result-screen.ts
@@ -34,6 +34,16 @@ const practiceSubgroup: CommandsSubgroup = {
       },
     },
     {
+      id: "practiseWordsBoth",
+      display: "both",
+      exec: (): void => {
+        PractiseWords.init("words", true);
+        TestLogic.restart({
+          practiseMissed: true,
+        });
+      },
+    },
+    {
       id: "practiseWordsCustom",
       display: "custom...",
       opensModal: true,


### PR DESCRIPTION
### Description

Added an option to practice both missed and slow words from the command line by doing esc -> Practice words -> both.

Implements #5753