### PR TITLE
fix(test): restart not working in long tests (@Leonabcd123)

### DIFF
--- a/frontend/src/ts/event-handlers/global.ts
+++ b/frontend/src/ts/event-handlers/global.ts
@@ -10,6 +10,7 @@ import { focusWords } from "../test/test-ui";
 import * as TestLogic from "../test/test-logic";
 import { navigate } from "../controllers/route-controller";
 import { isInputElementFocused } from "../input/input-element";
+import * as ManualRestart from "../test/manual-restart-tracker";
 
 document.addEventListener("keydown", (e) => {
   if (PageTransition.get()) return;
@@ -74,6 +75,9 @@ document.addEventListener("keydown", (e) => {
     ) {
       e.preventDefault();
       if (ActivePage.get() === "test") {
+        if (e.shiftKey) {
+          ManualRestart.set();
+        }
         TestLogic.restart();
       } else {
         void navigate("");

--- a/frontend/src/ts/input/handlers/keydown.ts
+++ b/frontend/src/ts/input/handlers/keydown.ts
@@ -11,6 +11,7 @@ import * as Notifications from "../../elements/notifications";
 import * as KeyConverter from "../../utils/key-converter";
 import * as ShiftTracker from "../../test/shift-tracker";
 import * as CompositionState from "../../states/composition";
+import * as ManualRestart from "../../test/manual-restart-tracker";
 import { canQuickRestart } from "../../utils/quick-restart";
 import * as CustomText from "../../test/custom-text";
 import * as CustomTextState from "../../states/custom-text-name";
@@ -28,6 +29,9 @@ export async function handleTab(e: KeyboardEvent, now: number): Promise<void> {
   if (Config.quickRestart === "tab") {
     e.preventDefault();
     if ((TestWords.hasTab && e.shiftKey) || !TestWords.hasTab) {
+      if (e.shiftKey) {
+        ManualRestart.set();
+      }
       TestLogic.restart();
       return;
     }
@@ -81,6 +85,9 @@ export async function handleEnter(
   if (Config.quickRestart === "enter") {
     e.preventDefault();
     if ((TestWords.hasNewline && e.shiftKey) || !TestWords.hasNewline) {
+      if (e.shiftKey) {
+        ManualRestart.set();
+      }
       TestLogic.restart();
       return;
     }
@@ -206,6 +213,11 @@ export async function onKeydown(event: KeyboardEvent): Promise<void> {
 
   if (event.key === "Escape" && Config.quickRestart === "esc") {
     event.preventDefault();
+
+    if (event.shiftKey) {
+      ManualRestart.set();
+    }
+
     TestLogic.restart();
     return;
   }


### PR DESCRIPTION
### Description

Fixed a bug where you can't use shift + quick restart key to restart long tests.
