### PR TITLE
fix(custom-text): Don't trim custom text (@Leonabcd123)

### DIFF
--- a/frontend/src/ts/modals/custom-text.ts
+++ b/frontend/src/ts/modals/custom-text.ts
@@ -269,7 +269,7 @@ function cleanUpText(): string[] {
 
   if (text === "") return [];
 
-  text = text.normalize().trim();
+  text = text.normalize();
   // text = text.replace(/[\r]/gm, " ");
 
   //replace any characters that look like a space with an actual space


### PR DESCRIPTION
### Description

Removed the `.trim()` call that deleted leading and trailing literal tabs or newlines from custom text.

This is to make sure that no matter what the custom text is, it will always stay the same after updating it. The current problem is that leading and trailing tabs and newlines will be removed when you click on "change" and "ok" for the second time (because they're now in their literal form, not \t and \n).