### PR TITLE
fix: caps-lock warning stuck on linux (@fehmer)

### DIFF
--- a/frontend/src/ts/test/caps-warning.ts
+++ b/frontend/src/ts/test/caps-warning.ts
@@ -22,9 +22,13 @@ function hide(): void {
 }
 
 function update(event: JQuery.KeyDownEvent | JQuery.KeyUpEvent): void {
-  const modState = event?.originalEvent?.getModifierState?.("CapsLock");
-  if (modState !== undefined) {
-    capsState = modState;
+  if (event?.originalEvent?.key === "CapsLock" && capsState !== null) {
+    capsState = !capsState;
+  } else {
+    const modState = event?.originalEvent?.getModifierState?.("CapsLock");
+    if (modState !== undefined) {
+      capsState = modState;
+    }
   }
 
   try {


### PR DESCRIPTION
Just pressing caps-lock on linux (firefox, chrome) activates the caps-lock warning but does not clear the caps-lock warning until pressing another key.