### PR TITLE
fix(config): sanitize config failing on array with multiple problems (@fehmer)

### DIFF
--- a/frontend/__tests__/utils/sanitize.spec.ts
+++ b/frontend/__tests__/utils/sanitize.spec.ts
@@ -151,6 +151,18 @@ describe("sanitize function", () => {
           optional: { name: "Alice", age: 23 },
         },
       },
+      {
+        input: {
+          name: "Alice",
+          //results in two errors on the same path. array with invalid value and not enough items
+          enumArray: ["invalid" as any],
+        },
+        expected: {
+          mandatory: false,
+          partial: { name: "Alice" }, //enumArray is removed
+          optional: false,
+        },
+      },
     ];
 
     it.for(testCases)("object mandatory with $input", ({ input, expected }) => {

--- a/frontend/src/ts/utils/sanitize.ts
+++ b/frontend/src/ts/utils/sanitize.ts
@@ -1,9 +1,12 @@
 import { z } from "zod";
 
 function removeProblems<T extends object | unknown[]>(
-  obj: T,
+  obj: T | undefined,
   problems: (number | string)[],
 ): T | undefined {
+  //already removed
+  if (obj === undefined) return undefined;
+
   if (Array.isArray(obj)) {
     if (problems.length === obj.length) return undefined;
 


### PR DESCRIPTION
Sanitize throws error if an object contains an array with 1) an invalid value and 2) too few items. The list of problems contains the path to the array twice and tries to remove the invalid element from the already deleted array.

Config object:

```json
 "customPolyglot": [
   "japanese"
 ]
```

