### PR TITLE
fix(pace-caret): prevent null dereference in update() (@byseif21)

### DIFF
--- a/frontend/src/ts/test/pace-caret.ts
+++ b/frontend/src/ts/test/pace-caret.ts
@@ -165,9 +165,9 @@ export async function update(expectedStepEnd: number): Promise<void> {
     currentSettings.timeout = setTimeout(
       () => {
         if (settings !== currentSettings) return;
-        update(expectedStepEnd + (currentSettings?.spc ?? 0) * 1000).catch(
+        update(expectedStepEnd + (currentSettings.spc ?? 0) * 1000).catch(
           () => {
-            settings = null;
+            if (settings === currentSettings) settings = null;
           },
         );
       },


### PR DESCRIPTION
### Description
  
* `update()` could hit a race where settings became  `null` between checks, causing a`TypeError` at runtime.

* Async callbacks (setTimeout) accessed the global settings after it was cleared, leading to runaway errors.
<img width="1887" height="755" alt="Screenshot 2025-12-12 135316" src="https://github.com/user-attachments/assets/ba6bd13c-c052-4870-ba7c-cfeae916b6dc" />


**fix**  
settings once (currentSettings) at the start of update() and use that for all property access and scheduling, so the loop never touches a null/stale reference.