### PR TITLE
fix(blind mode): Extra letters in blind mode causing caret problems (@Leonabcd123)

### DIFF
--- a/frontend/src/ts/utils/caret.ts
+++ b/frontend/src/ts/utils/caret.ts
@@ -299,11 +299,12 @@ export class Caret {
       let side: "beforeLetter" | "afterLetter" = "beforeLetter";
       if (options.letterIndex >= letters.length) {
         side = "afterLetter";
-        options.letterIndex = letters.length - 1;
-      }
 
-      if (Config.blindMode && options.letterIndex >= wordText?.length) {
-        options.letterIndex = wordText?.length - 1;
+        if (Config.blindMode) {
+          options.letterIndex = wordText?.length - 1;
+        } else {
+          options.letterIndex = letters.length - 1;
+        }
       }
 
       if (options.letterIndex < 0) {


### PR DESCRIPTION
### Description

- Enable blind mode
- Write extra letters
- Caret will jump to above the first letter in the word
