### PR TITLE
refactor: replace jQuery with DOM utils in caps lock warning (@MoushufAlam)

### DIFF
--- a/frontend/src/ts/test/caps-warning.ts
+++ b/frontend/src/ts/test/caps-warning.ts
@@ -1,7 +1,8 @@
 import Config from "../config";
 import * as Misc from "../utils/misc";
+import { qsr } from "../utils/dom";
 
-const el = document.querySelector("#capsWarning") as HTMLElement;
+const el = qsr("#capsWarning");
 
 export let capsState = false;
 
@@ -9,23 +10,23 @@ let visible = false;
 
 function show(): void {
   if (!visible) {
-    el?.classList.remove("hidden");
+    el.removeClass("hidden");
     visible = true;
   }
 }
 
 function hide(): void {
   if (visible) {
-    el?.classList.add("hidden");
+    el.addClass("hidden");
     visible = false;
   }
 }
 
-function update(event: JQuery.KeyDownEvent | JQuery.KeyUpEvent): void {
-  if (event?.originalEvent?.key === "CapsLock" && capsState !== null) {
+function update(event: KeyboardEvent): void {
+  if (event.key === "CapsLock" && capsState !== null) {
     capsState = !capsState;
   } else {
-    const modState = event?.originalEvent?.getModifierState?.("CapsLock");
+    const modState = event.getModifierState?.("CapsLock");
     if (modState !== undefined) {
       capsState = modState;
     }
@@ -40,8 +41,8 @@ function update(event: JQuery.KeyDownEvent | JQuery.KeyUpEvent): void {
   } catch {}
 }
 
-$(document).on("keyup", update);
+document.addEventListener("keyup", update);
 
-$(document).on("keydown", (event) => {
+document.addEventListener("keydown", (event) => {
   if (Misc.isMac()) update(event);
 });


### PR DESCRIPTION
### Description

Replaces jQuery usage with DOM utils for the caps lock warning.
Scope intentionally kept small per contributing guidelines.

### Checks

- [x] Adding/modifying Typescript code?
  - [x] I have used `qs`, `qsa` or `qsr` instead of JQuery selectors.
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.

<!-- label(optional scope): pull request title (@your_github_username) -->

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->
Related to #7186 
<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->
<!-- Also remove it if you are not following any issues. -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
