### PR TITLE
fix(blind-mode): make blind mode "on" text invisible  (@Leonabcd123)

### DIFF
--- a/frontend/src/html/pages/settings.html
+++ b/frontend/src/html/pages/settings.html
@@ -192,7 +192,7 @@
       <div class="buttons">
         <button data-config-value="false">off</button>
         <button data-config-value="true">
-          ⠀
+          &ensp;
           <!-- On is missing on purpose. -->
         </button>
       </div>


### PR DESCRIPTION
### Description

Use `&ensp;` instead of the current, visible character.