### PR TITLE
fix: wrong text direction when typing LTR in RTL language (@Leonabcd123)

### DIFF
--- a/frontend/src/styles/test.scss
+++ b/frontend/src/styles/test.scss
@@ -319,6 +319,10 @@
   &.rightToLeftTest {
     //flex-direction: row-reverse; // no need for hacking 😉, CSS fully support right-to-left languages
     direction: rtl;
+
+    .word {
+      unicode-bidi: bidi-override;
+    }
   }
   &.withLigatures {
     .word {
@@ -789,6 +793,10 @@
         &.rightToLeftTest {
           //flex-direction: row-reverse; // no need for hacking 😉, CSS fully support right-to-left languages
           direction: rtl;
+
+          .word {
+            unicode-bidi: bidi-override;
+          }
         }
         &.withLigatures {
           .word {


### PR DESCRIPTION
### Description

Mainly fixes some caret problems currently present when typing ltr characters in an rtl test.