### PR TITLE
fix(custom-mode): chart problems in custom mode (@Leonabcd123)

### DIFF
--- a/frontend/src/ts/test/test-logic.ts
+++ b/frontend/src/ts/test/test-logic.ts
@@ -915,7 +915,13 @@ export async function finish(difficultyFailed = false): Promise<void> {
 
   // stats
   const stats = TestStats.calculateFinalStats();
-  if (stats.time % 1 !== 0 && Config.mode !== "time") {
+  if (
+    stats.time % 1 !== 0 &&
+    !(
+      Config.mode === "time" ||
+      (Config.mode === "custom" && CustomText.getLimitMode() === "time")
+    )
+  ) {
     TestStats.setLastSecondNotRound();
   }
 


### PR DESCRIPTION
### Description

Round when user is in custom mode with limit mode being time.

Bug fixed:

- Switch to custom mode
- Set limit to some time
- Do tests until you get a finishing time of x.99
- Notice the last value in the chart is less than the value that came before it, and is the value that came before it -0.01
