### PR TITLE
fix(custom): ignore prototype properties in British English replacement rules (@byseif21)

### DIFF
--- a/frontend/__tests__/test/british-english.spec.ts
+++ b/frontend/__tests__/test/british-english.spec.ts
@@ -63,5 +63,10 @@ describe("british-english", () => {
       await expect(replace("'hello'", "")).resolves.toEqual("'hello'");
       await expect(replace("test", "")).resolves.toEqual("test");
     });
+
+    it("ignores prototype-related property names (e.g. constructor, __proto__)", async () => {
+      await expect(replace("constructor", "")).resolves.toEqual("constructor");
+      await expect(replace("__proto__", "")).resolves.toEqual("__proto__");
+    });
   });
 });

--- a/frontend/src/ts/test/british-english.ts
+++ b/frontend/src/ts/test/british-english.ts
@@ -700,6 +700,9 @@ export async function replace(
     ).join("-");
   } else {
     const cleanedWord = word.replace(/^[\W]+|[\W]+$/g, "").toLowerCase();
+    if (!Object.prototype.hasOwnProperty.call(replacementRules, cleanedWord)) {
+      return word;
+    }
     const rule = replacementRules[cleanedWord];
 
     if (rule === undefined) return word;


### PR DESCRIPTION
### Description

* custom mode (with british english enabled) could break with some words that matched an inherited JS object property, causing crashes
* made the replacement logic now ignores prototype property names on the rules object, added a small test for it.

Closes #7316 
