### PR TITLE
fix(settings-page): themes ui list shows clipped when selected or hovered (@byseif21)

### DIFF
--- a/frontend/src/styles/settings.scss
+++ b/frontend/src/styles/settings.scss
@@ -51,6 +51,11 @@
     display: grid;
     gap: 2rem;
     overflow: hidden;
+
+    &:has(.section.themes) {
+      overflow: visible;
+    }
+
     &.quickNav {
       justify-content: center;
       .links {
@@ -74,10 +79,6 @@
         }
       }
     }
-  }
-
-  .settingsGroup:has(.section.themes) {
-    overflow: visible;
   }
 
   .section {


### PR DESCRIPTION
484ab1bd5f1f7c598bd615da316567e5ca99174b