### PR TITLE
docs: Fix double whitespace in privacy-policy.html (@ChopChopp)

### DIFF
--- a/frontend/src/privacy-policy.html
+++ b/frontend/src/privacy-policy.html
@@ -388,7 +388,7 @@
           >
             HTTP cookie
           </a>
-          &nbsp; on Wikipedia.
+          on Wikipedia.
         </p>
 
         <h1 id="Usage_of_Cookies">How do we use cookies?</h1>


### PR DESCRIPTION
### Description

I removed the `&nbsp;` as it is explicity requesting a whitespace, eventhough the formatting is already naturally setting a whitespace.
This lead to a double whitespace:
<img width="673" height="33" alt="image" src="https://github.com/user-attachments/assets/84b4243f-a867-4cf9-a177-f0dfb5b35016" />
<!-- label(docs): Fix double whitespace in privacy-policy.html (@ChopChopp) -->