### PR TITLE
fix(event-handlers): commandOverride not working due to incorrect check (@byseif21)

### DIFF
--- a/frontend/src/ts/event-handlers/test.ts
+++ b/frontend/src/ts/event-handlers/test.ts
@@ -24,7 +24,7 @@ const testPage = qs(".pageTest");
 testPage?.onChild("click", "#testModesNotice .textButton", async (event) => {
   const target = event.childTarget as HTMLElement;
   const attr = target?.getAttribute("commands");
-  if (attr === undefined) return;
+  if (attr === null) return;
   Commandline.show({ subgroupOverride: attr as ConfigKey | ListsObjectKeys });
 });
 


### PR DESCRIPTION
it returns null when attribute doesn't exist, not undefined