### PR TITLE
fix: correct streak offset validation to allow .5 decrements (@Chaitanya-Keyal)

### DIFF
--- a/frontend/src/ts/modals/streak-hour-offset.ts
+++ b/frontend/src/ts/modals/streak-hour-offset.ts
@@ -84,7 +84,8 @@ async function apply(): Promise<void> {
     return;
   }
 
-  if (value < -11 || value > 12 || (value % 1 !== 0 && value % 1 !== 0.5)) {
+  // Check if value is whole number or ends in .5 (multiply by 2 to check if result is integer)
+  if (value < -11 || value > 12 || (value * 2) % 1 !== 0) {
     Notifications.add(
       "Streak offset must be between -11 and 12. Times ending in .5 can be used for 30-minute increments.",
       0,


### PR DESCRIPTION
### Description

The current streak hour offset validation fails for values like `-5.5` because `-5.5 % 1` evaluates to `-0.5`, causing the fractional check to fail.

This PR simplifies the validation logic by multiplying the value by 2 and checking whether the result is an integer. This correctly allows only whole-hour and half-hour (`.5`) offsets while handling negative values properly.

<img width="1667" height="1320" alt="Screenshot 2026-01-14 203300" src="https://github.com/user-attachments/assets/3c5ccef5-a173-4df7-9ff2-037d4417ae10" />


### Checks

- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.

<!-- label(optional scope): pull request title (@your_github_username) -->

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->

Closes #7204, related PRs #7269, #7362

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->
<!-- Also remove it if you are not following any issues. -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
