### PR TITLE
fix(edit-preset): error message when failing to add preset (@Leonabcd123)

### DIFF
--- a/frontend/src/ts/modals/edit-preset.ts
+++ b/frontend/src/ts/modals/edit-preset.ts
@@ -289,7 +289,7 @@ async function apply(): Promise<void> {
 
     if (response.status !== 200 || response.body.data === null) {
       Notifications.add(
-        "Failed to add preset" +
+        "Failed to add preset: " +
           response.body.message.replace(presetName, propPresetName),
         -1,
       );


### PR DESCRIPTION
### Description

Consistent with the error message when failing to add a tag, separates the `Failed to add preset` message from the details.