### PR TITLE
fix(streak-hour-offset): streak hour offset display isn't correct for some negative values (@Leonabcd123)

### DIFF
--- a/frontend/src/ts/modals/streak-hour-offset.ts
+++ b/frontend/src/ts/modals/streak-hour-offset.ts
@@ -58,7 +58,7 @@ function updatePreview(): void {
 
   newDate.setHours(newDate.getHours() - -1 * Math.floor(inputValue)); //idk why, but it only works when i subtract (so i have to negate inputValue)
   newDate.setMinutes(
-    newDate.getMinutes() - -1 * (((inputValue % 1) + 1) % 1 * 60),
+    newDate.getMinutes() - -1 * ((((inputValue % 1) + 1) % 1) * 60),
   );
 
   preview?.setHtml(`


### PR DESCRIPTION
### Description

When getting to around 12:00 using negative values in the streak hour offset modal, the new time shown isn't correct.