### PR TITLE
feat(theme): add Adwaita, dark and light variants (@poli0iq)

### DIFF
--- a/frontend/src/ts/constants/themes.ts
+++ b/frontend/src/ts/constants/themes.ts
@@ -1132,6 +1132,18 @@ export const themes: Record<ThemeName, Omit<Theme, "name">> = {
     subColor: "#0476f2",
     textColor: "#f0f0f0",
   },
+  adwaita_dark: {
+    bgColor: "#222226",
+    mainColor: "#81d0ff",
+    subColor: "#7b7b7b",
+    textColor: "#ffffff",
+  },
+  adwaita_light: {
+    bgColor: "#fafafb",
+    mainColor: "#a2326c",
+    subColor: "#8b8b8b",
+    textColor: "#333338",
+  },
 };
 
 export const ThemesList: Theme[] = Object.keys(themes)

--- a/frontend/static/themes/adwaita_dark.css
+++ b/frontend/static/themes/adwaita_dark.css
@@ -1,0 +1,12 @@
+:root {
+  --bg-color: #222226;
+  --main-color: #81d0ff;
+  --caret-color: #ffffff;
+  --sub-color: #7b7b7b;
+  --sub-alt-color: #2e2e32;
+  --text-color: #ffffff;
+  --error-color: #ff938c;
+  --error-extra-color: #ffc252;
+  --colorful-error-color: #ff938c;
+  --colorful-error-extra-color: #ffc252;
+}

--- a/frontend/static/themes/adwaita_light.css
+++ b/frontend/static/themes/adwaita_light.css
@@ -1,0 +1,12 @@
+:root {
+  --bg-color: #fafafb;
+  --main-color: #a2326c;
+  --caret-color: #333338;
+  --sub-color: #8b8b8b;
+  --sub-alt-color: #ebebed;
+  --text-color: #333338;
+  --error-color: #c30000;
+  --error-extra-color: #905400;
+  --colorful-error-color: #c30000;
+  --colorful-error-extra-color: #905400;
+}

--- a/packages/schemas/src/themes.ts
+++ b/packages/schemas/src/themes.ts
@@ -190,6 +190,8 @@ export const ThemeNameSchema = z.enum(
     "witch_girl",
     "pale_nimbus",
     "spiderman",
+    "adwaita_dark",
+    "adwaita_light",
   ],
   {
     errorMap: customEnumErrorHandler("Must be a known theme"),


### PR DESCRIPTION
### Description

Primary source of truth is https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.8/css-variables.html.
I've used standard accent colors (standalone versions) so that it's not completely monochrome: blue for the dark and pink for the light variants.

<img width="2868" height="1994" alt="dark" src="https://github.com/user-attachments/assets/07b5f812-b1d0-40eb-9f57-0a4075db1863" />
<img width="2868" height="1994" alt="dark-flipped" src="https://github.com/user-attachments/assets/34949a57-e863-4491-be17-95072a04dfad" />
<img width="2868" height="1994" alt="dark-colorful" src="https://github.com/user-attachments/assets/39a3426c-104c-4544-90bf-f7459741d71c" />
<img width="2868" height="1994" alt="light" src="https://github.com/user-attachments/assets/c3988cd0-9d43-4c5f-b042-70642e725f0f" />
<img width="2868" height="1994" alt="light-flipped" src="https://github.com/user-attachments/assets/493db6bc-2cd2-4718-92e7-af80332b18e2" />
<img width="2868" height="1994" alt="light-colorful" src="https://github.com/user-attachments/assets/54c58727-50ad-4d5b-a1f7-9f84aab8d28d" />
