### PR TITLE
fix: blur slider being visually blurred (@byseif21)

### DIFF
--- a/frontend/src/html/pages/settings.html
+++ b/frontend/src/html/pages/settings.html
@@ -1438,7 +1438,7 @@
       </div>
       <div class="text">Apply various effects to the custom background.</div>
       <div class="groups">
-        <div class="group blur">
+        <div class="group blur-filter">
           <div class="title">blur</div>
           <div class="value"></div>
           <input type="range" min="0" max="5" value="0" step="0.1" />

--- a/frontend/src/ts/elements/custom-background-filter.ts
+++ b/frontend/src/ts/elements/custom-background-filter.ts
@@ -55,7 +55,7 @@ export function apply(): void {
 
 function syncSliders(): void {
   section
-    .qs<HTMLInputElement>(".blur input")
+    .qs<HTMLInputElement>(".blur-filter input")
     ?.setValue(filters.blur.value.toString());
   section
     .qs<HTMLInputElement>(".brightness input")
@@ -69,7 +69,7 @@ function syncSliders(): void {
 }
 
 function updateNumbers(): void {
-  section.qs(".blur .value")?.setHtml(filters.blur.value.toFixed(1));
+  section.qs(".blur-filter .value")?.setHtml(filters.blur.value.toFixed(1));
   section
     .qs(".brightness .value")
     ?.setHtml(filters.brightness.value.toFixed(1));
@@ -90,9 +90,9 @@ function loadConfig(config: CustomBackgroundFilter): void {
   updateUI();
 }
 
-section.qs(".blur input")?.on("input", () => {
+section.qs(".blur-filter input")?.on("input", () => {
   filters.blur.value = parseFloat(
-    section.qs<HTMLInputElement>(".blur input")?.getValue() ?? "0",
+    section.qs<HTMLInputElement>(".blur-filter input")?.getValue() ?? "0",
   );
   updateNumbers();
   apply();


### PR DESCRIPTION
the blur slider class's triggering Tailwind’s `.blur` utility so the label renders blurred