### PR TITLE
fix: fontawesome icon visibility styles (@MirruK)

### DIFF
--- a/frontend/src/styles/vendor.scss
+++ b/frontend/src/styles/vendor.scss
@@ -1,6 +1,8 @@
 @import "fontawesome-5"; // the screenshotting library has some issues with css layers
 
-// fontawesome icon styles do not respect the hidden class from the hidden layer
+/* fontawesome icon styles do not respect the hidden class from the hidden layer.
+* By having these rules outside any layer we make sure that the display none is
+* correctly applied when an element possesses both a .fa* class and the hidden class */
 .fas.hidden,
 .fab.hidden,
 .fa.hidden,


### PR DESCRIPTION
Add styles for fontawesome icons to respect hidden and invisible classes

### Description

Icons were removed from layers, this caused the .hidden class to not have any effect on icons, this fixes the problem globally
