### PR TITLE
fix: merch banner image not visible on profile page (@fehmer)

### DIFF
--- a/frontend/src/ts/elements/merch-banner.tsx
+++ b/frontend/src/ts/elements/merch-banner.tsx
@@ -22,7 +22,7 @@ export function showIfNotClosedBefore(): void {
           </a>
         </>
       ),
-      imagePath: "./images/merch3.png",
+      imagePath: "/images/merch3.png",
       onClose: () => {
         closed.set(true);
       },


### PR DESCRIPTION
- open https://monkeytype.com/profile/Miodec tries to load https://monkeytype.com/profile/images/merch3.png
