### PR TITLE
fix(spanish_10k): correct spelling mistake in spanish_10k.json (@eswaldots)

### DIFF
--- a/frontend/static/languages/spanish_10k.json
+++ b/frontend/static/languages/spanish_10k.json
@@ -7783,7 +7783,7 @@
     "camas",
     "magdalena",
     "meramente",
-    "berengena",
+    "berenjena",
     "rechazado",
     "recibiendo",
     "siembra",


### PR DESCRIPTION
### Description

The word `berengena` has been changed to `berenjena` in spanish_10k.json

### Checks

- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.