### PR TITLE
docs: update formatter info to oxc (@vinayaksodar)

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -13,7 +13,7 @@
 
 ## Getting Started
 
-When contributing to Monkeytype, it's good to know our best practices, tips, and tricks. First, Monkeytype is written in ~~JavaScript~~ TypeScript, HTML, and CSS (in order of language usage within the project); thus, we assume you are comfortable with these languages or have basic knowledge of them. Our backend is in NodeJS and we use MongoDB to store our user data. Firebase is used for authentication. Redis is used to store ephemeral data (daily leaderboards, jobs via BullMQ, OAuth state parameters). Furthermore, we use oxc (oxfmt and oxlint) to format and lint our code.
+When contributing to Monkeytype, it's good to know our best practices, tips, and tricks. First, Monkeytype is written in ~~JavaScript~~ TypeScript, HTML, and CSS (in order of language usage within the project); thus, we assume you are comfortable with these languages or have basic knowledge of them. Our backend is in NodeJS and we use MongoDB to store our user data. Firebase is used for authentication. Redis is used to store ephemeral data (daily leaderboards, jobs via BullMQ, OAuth state parameters). Furthermore, we use Oxc (Oxfmt and Oxlint) to format and lint our code.
 
 ## How to Contribute
 

--- a/docs/CONTRIBUTING_ADVANCED.md
+++ b/docs/CONTRIBUTING_ADVANCED.md
@@ -148,7 +148,7 @@ If you are on a UNIX system and you get a spawn error, run npm with `sudo`.
 
 ## Standards and Guidelines
 
-Code formatting and linting is enforced by [oxc (oxfmt and oxlint)](https://github.com/oxc-project/oxc), which automatically runs every time you make a commit.
+Code formatting and linting is enforced by [Oxc (Oxfmt and Oxlint)](https://github.com/oxc-project/oxc), which automatically runs every time you make a commit.
 
 For guidelines on commit messages, adding themes, languages, or quotes, please refer to [CONTRIBUTING.md](./CONTRIBUTING.md). Following these guidelines will increase the chances of getting your change accepted.
 


### PR DESCRIPTION
Updates documentation to reflect the project's transition from Prettier to `oxc` (`oxfmt` and `oxlint`) for code formatting and linting.

- `docs/CONTRIBUTING.md`
- `docs/CONTRIBUTING_ADVANCED.md`

Fixes #7491