### PR TITLE
impr: add details to speed histogram (@fehmer)

### DIFF
--- a/frontend/src/ts/components/pages/AboutPage.tsx
+++ b/frontend/src/ts/components/pages/AboutPage.tsx
@@ -156,13 +156,21 @@ export function AboutPage(): JSXElement {
                       animation: { duration: 250 },
                       intersect: false,
                       mode: "index",
+                      callbacks: {
+                        afterLabel: (context) => {
+                          return (
+                            (context.raw as { topPercentage?: string })
+                              .topPercentage ?? ""
+                          );
+                        },
+                      },
                     },
                   },
                 }}
               />
               <div class="text-right text-xs text-sub">
-                distribution of {numberOfHistogramRecords(data?.data)} time 60
-                leaderboard results (wpm)
+                distribution of time 60 leaderboard results (wpm) <br />
+                {numberOfHistogramRecords(data?.data)} total results
               </div>
             </>
           )}

--- a/frontend/src/ts/queries/public.ts
+++ b/frontend/src/ts/queries/public.ts
@@ -85,8 +85,14 @@ async function fetchSpeedHistogram(): Promise<
 
   const data = response.body.data;
 
-  const histogramChartDataBucketed: { x: number; y: number }[] = [];
+  const histogramChartDataBucketed: {
+    x: number;
+    y: number;
+    topPercentage?: string;
+  }[] = [];
   const labels: string[] = [];
+  const sum = Object.values(data).reduce((sum, it) => (sum += it), 0);
+  let topPercentage = 100;
 
   const keys = Object.keys(data).sort(
     (a, b) => parseInt(a, 10) - parseInt(b, 10),
@@ -94,9 +100,12 @@ async function fetchSpeedHistogram(): Promise<
   for (const [i, key] of keys.entries()) {
     const nextKey = keys[i + 1];
     const bucket = parseInt(key, 10);
+    topPercentage -= ((data[bucket] as number) / sum) * 100;
     histogramChartDataBucketed.push({
       x: bucket,
       y: data[bucket] as number,
+      topPercentage:
+        topPercentage > 0.01 ? `top ${topPercentage.toFixed(2)}%` : undefined,
     });
     labels.push(`${bucket} - ${bucket + 9}`);
     if (nextKey !== undefined && bucket + 10 !== parseInt(nextKey, 10)) {


### PR DESCRIPTION
- adds the total amount of entries to the histogram footer 
- adds top percentage to tooltip label
- set minimum bar height to avoid issue with very small bars having disproportionate sizes