### PR TITLE
fix(test): recover pace caret after word generation gaps (@anuragkej)

### DIFF
--- a/frontend/__tests__/test/pace-caret.spec.ts
+++ b/frontend/__tests__/test/pace-caret.spec.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __testing as ConfigTesting } from "../../src/ts/config";
+import * as PaceCaret from "../../src/ts/test/pace-caret";
+import * as TestState from "../../src/ts/test/test-state";
+import * as TestWords from "../../src/ts/test/test-words";
+
+describe("pace-caret", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    ConfigTesting.replaceConfig({
+      paceCaret: "custom",
+      paceCaretCustomSpeed: 100,
+      blindMode: false,
+    });
+    TestState.setActive(true);
+    TestState.setResultVisible(false);
+    TestWords.words.reset();
+    PaceCaret.reset();
+  });
+
+  afterEach(() => {
+    PaceCaret.reset();
+    TestWords.words.reset();
+    TestState.setActive(false);
+    TestState.setResultVisible(false);
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("recovers when the pace caret reaches words that are not generated yet", async () => {
+    TestWords.words.push("alpha", 0);
+    await PaceCaret.init();
+
+    const initialSettings = PaceCaret.settings;
+    expect(initialSettings).not.toBeNull();
+    if (initialSettings === null) {
+      throw new Error("Pace caret settings were not initialized");
+    }
+
+    const showMock = vi.spyOn(PaceCaret.caret, "show");
+    const hideMock = vi.spyOn(PaceCaret.caret, "hide");
+    vi.spyOn(PaceCaret.caret, "isHidden").mockReturnValue(true);
+    vi.spyOn(PaceCaret.caret, "goTo").mockImplementation(() => undefined);
+
+    const endOfFirstWord = TestWords.words.get(0)?.length ?? 1;
+    initialSettings.currentWordIndex = 0;
+    initialSettings.currentLetterIndex = endOfFirstWord;
+    initialSettings.correction = 1;
+
+    await PaceCaret.update(0);
+
+    expect(PaceCaret.settings).not.toBeNull();
+    expect(PaceCaret.settings?.currentWordIndex).toBe(0);
+    expect(PaceCaret.settings?.currentLetterIndex).toBe(endOfFirstWord);
+    expect(PaceCaret.settings?.correction).toBe(1);
+    expect(hideMock).toHaveBeenCalled();
+    expect(showMock).not.toHaveBeenCalled();
+
+    if (PaceCaret.settings !== null) {
+      PaceCaret.settings.correction = 0;
+    }
+    TestWords.words.push("beta", 1);
+    await PaceCaret.update(0);
+
+    expect(PaceCaret.settings?.currentWordIndex).toBe(1);
+    expect(PaceCaret.settings?.currentLetterIndex).toBe(0);
+    expect(showMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops retrying when no additional words can be generated", async () => {
+    ConfigTesting.replaceConfig({
+      paceCaret: "custom",
+      paceCaretCustomSpeed: 100,
+      blindMode: false,
+      mode: "words",
+      words: 1,
+    });
+    TestWords.words.push("alpha", 0);
+    await PaceCaret.init();
+
+    const currentSettings = PaceCaret.settings;
+    expect(currentSettings).not.toBeNull();
+    if (currentSettings === null) {
+      throw new Error("Pace caret settings were not initialized");
+    }
+
+    vi.spyOn(PaceCaret.caret, "isHidden").mockReturnValue(true);
+    vi.spyOn(PaceCaret.caret, "goTo").mockImplementation(() => undefined);
+
+    const endOfFirstWord = TestWords.words.get(0)?.length ?? 1;
+    currentSettings.currentWordIndex = 0;
+    currentSettings.currentLetterIndex = endOfFirstWord;
+    currentSettings.correction = 1;
+
+    await PaceCaret.update(0);
+
+    expect(vi.getTimerCount()).toBe(0);
+    expect(PaceCaret.settings).toBeNull();
+  });
+});

--- a/frontend/src/ts/test/pace-caret.ts
+++ b/frontend/src/ts/test/pace-caret.ts
@@ -3,6 +3,8 @@ import Config from "../config";
 import * as DB from "../db";
 import * as Misc from "../utils/misc";
 import * as TestState from "./test-state";
+import * as CustomText from "./custom-text";
+import * as WordsGenerator from "./words-generator";
 import * as ConfigEvent from "../observables/config-event";
 import { getActiveFunboxes } from "./funbox/list";
 import { Caret } from "../utils/caret";
@@ -139,11 +141,25 @@ export async function update(expectedStepEnd: number): Promise<void> {
     return;
   }
 
+  const nextExpectedStepEnd =
+    expectedStepEnd + (currentSettings.spc ?? 0) * 1000;
+
+  if (!incrementLetterIndex()) {
+    if (shouldRetryWhenWordsMayStillGenerate(currentSettings)) {
+      scheduleUpdate(
+        currentSettings,
+        nextExpectedStepEnd,
+        Math.max(16, (currentSettings.spc ?? 0) * 1000),
+      );
+    } else {
+      settings = null;
+    }
+    return;
+  }
+
   if (caret.isHidden()) {
     caret.show();
   }
-
-  incrementLetterIndex();
 
   try {
     const now = performance.now();
@@ -162,22 +178,63 @@ export async function update(expectedStepEnd: number): Promise<void> {
       },
     });
 
-    currentSettings.timeout = setTimeout(
-      () => {
-        if (settings !== currentSettings) return;
-        update(expectedStepEnd + (currentSettings.spc ?? 0) * 1000).catch(
-          () => {
-            if (settings === currentSettings) settings = null;
-          },
-        );
-      },
-      Math.max(0, duration),
-    );
+    scheduleUpdate(currentSettings, nextExpectedStepEnd, Math.max(0, duration));
   } catch (e) {
     console.error(e);
     caret.hide();
     return;
   }
+}
+
+function scheduleUpdate(
+  currentSettings: Settings,
+  nextExpectedStepEnd: number,
+  delay: number,
+): void {
+  currentSettings.timeout = setTimeout(() => {
+    if (settings !== currentSettings) return;
+    update(nextExpectedStepEnd).catch(() => {
+      if (settings === currentSettings) settings = null;
+    });
+  }, delay);
+}
+
+function shouldRetryWhenWordsMayStillGenerate(
+  currentSettings: Settings,
+): boolean {
+  if (settings !== currentSettings) return false;
+  return !areAllTestWordsGenerated();
+}
+
+function areAllTestWordsGenerated(): boolean {
+  if (Config.mode === "words") {
+    return TestWords.words.length >= Config.words && Config.words > 0;
+  }
+
+  if (Config.mode === "quote") {
+    return (
+      TestWords.words.length >= (TestWords.currentQuote?.textSplit?.length ?? 0)
+    );
+  }
+
+  if (Config.mode === "custom") {
+    const limitMode = CustomText.getLimitMode();
+    const limitValue = CustomText.getLimitValue();
+
+    if (limitMode === "word") {
+      return TestWords.words.length >= limitValue && limitValue !== 0;
+    }
+
+    if (limitMode === "section") {
+      return (
+        WordsGenerator.sectionIndex >= limitValue &&
+        WordsGenerator.currentSection.length === 0 &&
+        limitValue !== 0
+      );
+    }
+  }
+
+  return false;
 }
 
 export function reset(): void {
@@ -188,8 +245,12 @@ export function reset(): void {
   startTimestamp = 0;
 }
 
-function incrementLetterIndex(): void {
-  if (settings === null) return;
+function incrementLetterIndex(): boolean {
+  if (settings === null) return false;
+
+  const previousWordIndex = settings.currentWordIndex;
+  const previousLetterIndex = settings.currentLetterIndex;
+  const previousCorrection = settings.correction;
 
   try {
     settings.currentLetterIndex++;
@@ -228,13 +289,15 @@ function incrementLetterIndex(): void {
         }
       }
     }
-  } catch (e) {
-    //out of words
-    settings = null;
-    console.log("pace caret out of words");
+  } catch {
+    settings.currentWordIndex = previousWordIndex;
+    settings.currentLetterIndex = previousLetterIndex;
+    settings.correction = previousCorrection;
     caret.hide();
-    return;
+    return false;
   }
+
+  return true;
 }
 
 export function handleSpace(correct: boolean, currentWord: string): void {


### PR DESCRIPTION
### Description

This PR fixes a pace-caret edge case triggered with Plus Three (and similar dynamic word generation scenarios):

- keeps pace-caret state when it briefly runs past words that are not generated yet,
- retries safely while additional words may still be generated,
- stops retries cleanly when word exhaustion is terminal (to avoid an endless hidden-caret timer loop),
- adds targeted unit coverage for both recovery and terminal-stop paths.

### Checks

- [ ] Adding quotes?
  - [ ] Make sure to include translations for the quotes in the description (or another comment) so we can verify their content.
- [ ] Adding a language?
  - Make sure to follow the [languages documentation](https://github.com/monkeytypegame/monkeytype/blob/master/docs/LANGUAGES.md)
  - [ ] Add language to `packages/schemas/src/languages.ts`
  - [ ] Add language to exactly one group in `frontend/src/ts/constants/languages.ts`
  - [ ] Add language json file to `frontend/static/languages`
- [ ] Adding a theme?
  - Make sure to follow the [themes documentation](https://github.com/monkeytypegame/monkeytype/blob/master/docs/THEMES.md)
  - [ ] Add theme to `packages/schemas/src/themes.ts`
  - [ ] Add theme to `frontend/src/ts/constants/themes.ts`
  - [ ] (optional) Add theme css file to `frontend/static/themes`
  - [ ] Add some screenshots of the theme, especially with different test settings (colorful, flip colors) to your pull request
- [ ] Adding a layout?
  - [ ] Make sure to follow the [layouts documentation](https://github.com/monkeytypegame/monkeytype/blob/master/docs/LAYOUTS.md)
  - [ ] Add layout to `packages/schemas/src/layouts.ts`
  - [ ] Add layout json file to `frontend/static/layouts`
- [ ] Adding a font?
  - Make sure to follow the [fonts documentation](https://github.com/monkeytypegame/monkeytype/blob/master/docs/FONTS.md)
  - [ ] Add font file to `frontend/static/webfonts`
  - [ ] Add font to `packages/schemas/src/fonts.ts`
  - [ ] Add font to `frontend/src/ts/constants/fonts.ts`
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.

Closes #7527
