### PR TITLE
fix(test): recover pace caret after word generation gaps (@anuragkej)

### DIFF
--- a/frontend/__tests__/test/pace-caret.spec.ts
+++ b/frontend/__tests__/test/pace-caret.spec.ts
@@ -61,11 +61,48 @@ describe("pace-caret", () => {
       PaceCaret.settings.correction = 0;
     }
     TestWords.words.push("beta", 1);
-    await PaceCaret.update(0);
+
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+    await vi.runOnlyPendingTimersAsync();
+    await Promise.resolve();
 
     expect(PaceCaret.settings?.currentWordIndex).toBe(1);
     expect(PaceCaret.settings?.currentLetterIndex).toBe(0);
     expect(showMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("catches up retry timing when schedule is already behind", async () => {
+    ConfigTesting.replaceConfig({
+      paceCaret: "custom",
+      paceCaretCustomSpeed: 60,
+      blindMode: false,
+      mode: "time",
+      time: 30,
+    });
+    TestWords.words.push("alpha", 0);
+    await PaceCaret.init();
+
+    const currentSettings = PaceCaret.settings;
+    expect(currentSettings).not.toBeNull();
+    if (currentSettings === null) {
+      throw new Error("Pace caret settings were not initialized");
+    }
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    vi.spyOn(performance, "now").mockReturnValue(1000);
+    vi.spyOn(PaceCaret.caret, "isHidden").mockReturnValue(true);
+    vi.spyOn(PaceCaret.caret, "goTo").mockImplementation(() => undefined);
+
+    const endOfFirstWord = TestWords.words.get(0)?.length ?? 1;
+    currentSettings.currentWordIndex = 0;
+    currentSettings.currentLetterIndex = endOfFirstWord;
+    currentSettings.correction = 1;
+
+    await PaceCaret.update(0);
+
+    expect(setTimeoutSpy).toHaveBeenCalled();
+    const retryDelay = setTimeoutSpy.mock.calls.at(-1)?.[1];
+    expect(retryDelay).toBe(16);
   });
 
   it("stops retrying when no additional words can be generated", async () => {

--- a/frontend/src/ts/test/pace-caret.ts
+++ b/frontend/src/ts/test/pace-caret.ts
@@ -149,7 +149,7 @@ export async function update(expectedStepEnd: number): Promise<void> {
       scheduleUpdate(
         currentSettings,
         nextExpectedStepEnd,
-        Math.max(16, (currentSettings.spc ?? 0) * 1000),
+        Math.max(16, getDelayUntilStepEnd(nextExpectedStepEnd)),
       );
     } else {
       settings = null;
@@ -162,9 +162,7 @@ export async function update(expectedStepEnd: number): Promise<void> {
   }
 
   try {
-    const now = performance.now();
-    const absoluteStepEnd = startTimestamp + expectedStepEnd;
-    const duration = absoluteStepEnd - now;
+    const duration = getDelayUntilStepEnd(expectedStepEnd);
 
     caret.goTo({
       wordIndex: currentSettings.currentWordIndex,
@@ -184,6 +182,10 @@ export async function update(expectedStepEnd: number): Promise<void> {
     caret.hide();
     return;
   }
+}
+
+function getDelayUntilStepEnd(stepEnd: number): number {
+  return startTimestamp + stepEnd - performance.now();
 }
 
 function scheduleUpdate(


### PR DESCRIPTION
### Description

This PR fixes a pace-caret edge case triggered with Plus Three (and similar dynamic word generation scenarios):

- keeps pace-caret state when it briefly runs past words that are not generated yet,
- retries safely while additional words may still be generated,
- stops retries cleanly when word exhaustion is terminal (to avoid an endless hidden-caret timer loop),
- adds targeted unit coverage for both recovery and terminal-stop paths.

Supersedes #7559 (GitHub would not allow reopening it after the source repo was detached from fork network).

### Checks

- [ ] Adding quotes?
  - [ ] Make sure to include translations for the quotes in the description (or another comment) so we can verify their content.
- [ ] Adding a language?
  - Make sure to follow the [languages documentation](https://github.com/monkeytypegame/monkeytype/blob/master/docs/LANGUAGES.md)
  - [ ] Add language to `packages/schemas/src/languages.ts`
  - [ ] Add language to exactly one group in `frontend/src/ts/constants/languages.ts`
  - [ ] Add language json file to `frontend/static/languages`
- [ ] Adding a theme?
  - Make sure to follow the [themes documentation](https://github.com/monkeytypegame/monkeytype/blob/master/docs/THEMES.md)
  - [ ] Add theme to `packages/schemas/src/themes.ts`
  - [ ] Add theme to `frontend/src/ts/constants/themes.ts`
  - [ ] (optional) Add theme css file to `frontend/static/themes`
  - [ ] Add some screenshots of the theme, especially with different test settings (colorful, flip colors) to your pull request
- [ ] Adding a layout?
  - [ ] Make sure to follow the [layouts documentation](https://github.com/monkeytypegame/monkeytype/blob/master/docs/LAYOUTS.md)
  - [ ] Add layout to `packages/schemas/src/layouts.ts`
  - [ ] Add layout json file to `frontend/static/layouts`
- [ ] Adding a font?
  - Make sure to follow the [fonts documentation](https://github.com/monkeytypegame/monkeytype/blob/master/docs/FONTS.md)
  - [ ] Add font file to `frontend/static/webfonts`
  - [ ] Add font to `packages/schemas/src/fonts.ts`
  - [ ] Add font to `frontend/src/ts/constants/fonts.ts`
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.

Closes #7527
