### PR TITLE
fix(account-chart): prevent scroll when clicking outside chart (@byseif21)

### DIFF
--- a/frontend/src/ts/pages/account.ts
+++ b/frontend/src/ts/pages/account.ts
@@ -1040,25 +1040,23 @@ qs(".pageAccount .loadMoreButton")?.on("click", () => {
 
 qs(".pageAccount #accountHistoryChart")?.on("click", () => {
   const chart = ChartController.accountHistory;
+  const active = chart.tooltip?.getActiveElements?.() ?? [];
+  if (!active.length) return;
 
-  const hasActive = (chart.tooltip?.getActiveElements?.() ?? []).length > 0;
-  if (!hasActive) return;
-
-  const index = ChartController.accountHistoryActiveIndex;
+  const index = active[0]?.index;
   if (index === undefined) return;
+
   loadMoreLines(index);
 
   const resultId = filteredResults[index]?._id;
   if (resultId === undefined) {
     throw new Error("Cannot find result for index " + index);
   }
+
   const element = qs(`.resultRow[data-id="${resultId}"]`);
   qsa(".resultRow").removeClass("active");
 
-  element?.scrollIntoView({
-    block: "center",
-  });
-
+  element?.scrollIntoView({ block: "center" });
   element?.addClass("active");
 });
 


### PR DESCRIPTION
issue: clicking chart labels scrolls to a record

* to reproduce
1- account history chart under the filters.
2- click on the “Words per Minute” or “Accuracy” labels on the sides of the chart.
3- page scrolls to a record in the results table even if no chart dot was clicked.