### PR TITLE
feat: add lefthand funbox for left-hand-only typing practice (@gokul1108)

### DIFF
--- a/frontend/src/ts/test/funbox/funbox-functions.ts
+++ b/frontend/src/ts/test/funbox/funbox-functions.ts
@@ -564,6 +564,15 @@ const list: Partial<Record<FunboxName, FunboxFunctions>> = {
       else return "";
     },
   },
+  lefthand: {
+    async withWords(words?: string[]): Promise<Wordset> {
+      const LEFT_HAND_KEYS = new Set("qwertasdfgzxcvb");
+      const filtered = (words ?? []).filter((w) =>
+        [...w.toLowerCase()].every((ch) => LEFT_HAND_KEYS.has(ch)),
+      );
+      return new Wordset(filtered.length > 0 ? filtered : ["test"]);
+    },
+  },
   pseudolang: {
     async withWords(words?: string[]): Promise<Wordset> {
       if (words !== undefined) return new PseudolangWordGenerator(words);

--- a/packages/funbox/src/list.ts
+++ b/packages/funbox/src/list.ts
@@ -323,6 +323,14 @@ const list: Record<FunboxName, FunboxMetadata> = {
     frontendFunctions: ["getWord"],
     name: "weakspot",
   },
+  lefthand: {
+    description: "Only words typeable with the left hand.",
+    canGetPb: false,
+    difficultyLevel: 1,
+    properties: ["changesWordsFrequency"],
+    frontendFunctions: ["withWords"],
+    name: "lefthand",
+  },
   pseudolang: {
     description: "Nonsense words that look like the current language.",
     canGetPb: false,

--- a/packages/schemas/src/configs.ts
+++ b/packages/schemas/src/configs.ts
@@ -321,6 +321,7 @@ export const FunboxNameSchema = z.enum([
   "asl",
   "rot13",
   "no_quit",
+  "lefthand",
 ]);
 export type FunboxName = z.infer<typeof FunboxNameSchema>;
 


### PR DESCRIPTION
Description

Add a new "lefthand" funbox that filters words to only those typeable with the left hand on a QWERTY layout (keys: `qwertasdfgzxcvb`). Useful for practicing weak left-hand typing.

Changes:
- `packages/schemas/src/configs.ts` — Added `"lefthand"` to `FunboxNameSchema`
- `packages/funbox/src/list.ts` — Added funbox metadata entry
- `frontend/src/ts/test/funbox/funbox-functions.ts` — Implemented `withWords` that filters language words to left-hand-only words