### PR TITLE
fix(privacy-policy): missing whitespace in privacy policy page (@Leonabcd123, @miodec)

### DIFF
--- a/frontend/src/privacy-policy.html
+++ b/frontend/src/privacy-policy.html
@@ -383,7 +383,14 @@
           >
             HTTP cookie
           </a>
-          <!-- As long as the a tag has display: inline-block, this will render correctly -->
+          <!--
+	    We need this nbsp to make sure there's no missing whitespace in production.
+            This is because without it the minifier collapses the whitespace after 
+	    "HTTP cookie" and the one after the closing `a` tag into a single space  
+	    located after "HTTP cookie" (inside the `a` tag), and because the `a` tag
+	    has display: inline-block, the space will not be rendered. Use nbsp to make
+	    sure the minifier doesn't remove it.
+	  -->
           &nbsp;on Wikipedia.
         </p>
 


### PR DESCRIPTION
### Description

Adds the missing whitespace here:
<img width="534" height="52" alt="image" src="https://github.com/user-attachments/assets/f3f116fa-2ebd-4d28-a489-2758d2839640" />