### PR TITLE
fix(exact-quote-search): results can be interpreted as regex (@Leonabcd123)

### DIFF
--- a/frontend/src/ts/modals/quote-search.ts
+++ b/frontend/src/ts/modals/quote-search.ts
@@ -225,7 +225,7 @@ function exactSearch(quotes: Quote[], captured: RegExp[]): [Quote[], string[]] {
         break;
       }
 
-      currentMatches.push(match[0]);
+      currentMatches.push(RegExp.escape(match[0]));
     }
 
     if (!noMatch) {


### PR DESCRIPTION
### Description

Steps to reproduce:

1. Search for `"("`
2. Open console
3. See error

Related #7658