### PR TITLE
fix(test): disable solid HMR in tests to fix path error on Windows (@nadalaba)

### DIFF
--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -6,7 +6,7 @@ import solidPlugin from "vite-plugin-solid";
 const plugins = [
   languageHashes({ skip: true }),
   envConfig({ isDevelopment: true, clientVersion: "TESTING", env: {} }),
-  solidPlugin(),
+  solidPlugin({ hot: false }),
 ];
 
 export const projects: UserWorkspaceConfig[] = [


### PR DESCRIPTION
### Description

Solid’s refresh runtime is injecting a virtual module that resolves to an invalid `file:///@` URL causing tests to fail on Windows:

> TypeError: The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received 'file:///@solid-refresh'

HMR isn’t used in vitest's SSR test environment, so disabling it on all platforms is safe.