### PR TITLE
fix(custom-text): mode 'simple' isn't saved when delimiter is pipe (@Leonabcd123)

### DIFF
--- a/frontend/src/ts/modals/custom-text.ts
+++ b/frontend/src/ts/modals/custom-text.ts
@@ -189,8 +189,7 @@ async function beforeAnimation(
 
   if (
     state.customTextMode === "repeat" &&
-    (CustomText.getLimitMode() === "word" ||
-      CustomText.getLimitMode() === "section") &&
+    CustomText.getLimitMode() !== "time" &&
     CustomText.getLimitValue() === CustomText.getText().length
   ) {
     state.customTextMode = "simple";


### PR DESCRIPTION
### Description

Steps to reproduce:

1. Create a custom text with a single word.
2. Set `word delimiter` to `pipe`.
3. Set `mode` to `simple`.
4. Click `ok`.
5. Click on `change`.
6. Notice how the mode is now `repeat` with `limit` being `1`.
