### PR TITLE
impr(input-validation): clean preset name input when adding (@byseif21)

### DIFF
--- a/frontend/src/ts/elements/input-validation.ts
+++ b/frontend/src/ts/elements/input-validation.ts
@@ -190,6 +190,7 @@ export class ValidatedHtmlInputElement<
 
   override setValue(val: string | null): this {
     if (val === null) {
+      super.setValue("");
       this.indicator.hide();
       this.currentStatus = { status: "checking", success: false };
     } else {


### PR DESCRIPTION
`ValidatedHtmlInputElement` would reset its validation status but keep the old text in the input field

1- go to presets
2- click edit from one of the existing ones
3- go back and click add preset
4- notice the edit one's name is there