### PR TITLE
fix: vendor-specific styles overriding standard properties (@nadalaba)

### DIFF
--- a/frontend/src/styles/test.scss
+++ b/frontend/src/styles/test.scss
@@ -192,8 +192,8 @@
 }
 
 #words {
-  height: fit-content;
   height: -moz-fit-content;
+  height: fit-content;
   padding-bottom: 0.5em; // to account for hints of the bottom line
   display: flex;
   flex-wrap: wrap;
@@ -344,8 +344,8 @@
   }
   &.blurred {
     opacity: 0.25;
-    filter: blur(4px);
     -webkit-filter: blur(4px);
+    filter: blur(4px);
   }
 
   &.blind {
@@ -898,8 +898,8 @@
     }
 
     #resultReplay .words {
-      user-select: none;
       -webkit-user-select: none;
+      user-select: none;
     }
 
     .chart {


### PR DESCRIPTION
1. switch tape off
2. switch to tape letter
3. `#words` height will keep its old height without fitting content
<img width="2559" height="1318" alt="tape" src="https://github.com/user-attachments/assets/9cab470a-21fd-4734-8d6a-64c63d075fa7" />

This happens because `height: -moz-fit-content` overrode `height: fit-content`, and vite8's cssMinify ([lightningCSS](https://lightningcss.dev/)) removes overridden properties.